### PR TITLE
fix: refine mount configurations and update VSCode extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,11 +21,10 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                "kaiwood.endwise",
-                // "castwide.solargraph",
                 "Shopify.ruby-extensions-pack",
+                "castwide.solargraph",
                 "KoichiSasada.vscode-rdbg",
-                "hridoy.rails-snippets"
+                "kaiwood.endwise"
             ]
         }
     },
@@ -33,7 +32,6 @@
     // "remoteUser": "root"
     "mounts": [
         "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached",
-        // "source=${localEnv:HOME}/.gitconfig,target=~/.gitconfig,type=bind,consistency=cached",
-        "source=${localWorkspaceFolder}/vendor/bundle,target=/workspaces/${localWorkspaceFolderBasename}/vendor/bundle,type=bind,consistency=cached"
+        "source=${localWorkspaceFolder}/vendor/bundle,target=/workspaces/${localWorkspaceFolderBasename}/vendor/bundle,type=cache,consistency=cached"
     ]
 }


### PR DESCRIPTION
This pull request updates the `.devcontainer/devcontainer.json` configuration to improve the development environment setup, mainly focusing on VS Code extensions and workspace mount options.

Development environment configuration:

* Reordered and updated the list of VS Code extensions: moved `kaiwood.endwise` to the end, re-enabled `castwide.solargraph`, and removed `hridoy.rails-snippets` for a more relevant Ruby development experience.

Workspace mount optimization:

* Changed the mount type for `vendor/bundle` from `bind` to `cache` to improve performance and consistency when using dependencies in the development container.