### PR TITLE
fix: サインインをサインアップに修正

### DIFF
--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,7 +1,7 @@
 <div class="form-wrapper">
   <div class="form-wrapper__container">
-    <% content_for :title, "サインイン" %>
-    <h1 class="form-wrapper__title">サインイン</h1>
+    <% content_for :title, "サインアップ" %>
+    <h1 class="form-wrapper__title">サインアップ</h1>
     <%= render "form", user: @user %>
   </div>
 </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- スタイル
  - ユーザー登録ページの文言を「サインイン」から「サインアップ」に統一。
  - ページタイトルと見出しに反映し、画面上の表記を一貫化。フォーム動作やエラーハンドリングへの影響はありません。
  - 対象は新規登録画面のみで、他画面やナビゲーションには影響しません。
  - 用語整備により初回登録フローの分かりやすさを向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->