### PR TITLE
feat: ユーザーがログイン状態でnewページにアクセスすることを禁止

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
   allow_unauthenticated_access
   before_action :set_user, only: %i[ show edit update destroy ]
+  before_action :redirect_if_authenticated, only: %i[ new create ]
   layout "main", only: [ :new ]
 
   # GET /users or /users.json
@@ -60,6 +61,13 @@ class UsersController < ApplicationController
   end
 
   private
+    # ログイン済みユーザーを新規登録ページから排除
+    def redirect_if_authenticated
+      if authenticated?
+        redirect_to root_path, alert: t("flash.users.already_logged_in")
+      end
+    end
+
     # Use callbacks to share common setup or constraints between actions.
     def set_user
       @user = User.find(params.expect(:id))

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,6 +4,7 @@ ja:
             created: "アカウントが正常に作成されました。"
             updated: "ユーザー情報を更新しました。"
             destroyed: "ユーザーを削除しました。"
+            already_logged_in: "既にログインしています。"
         reviews:
             created: "レビューを投稿しました。"
             updated: "レビューを更新しました。"

--- a/test/integration/user_authentication_flow_test.rb
+++ b/test/integration/user_authentication_flow_test.rb
@@ -121,4 +121,42 @@ class UserAuthenticationFlowTest < ActionDispatch::IntegrationTest
     # サブミットボタンが存在することを確認
     assert_select "input[type='submit']"
   end
+
+  test "authenticated user cannot access signup page" do
+    # ログインする
+    sign_in_as(@user, password: "password")
+    assert_redirected_to root_url
+
+    # 新規登録ページにアクセスを試みる
+    get new_user_path
+
+    # rootにリダイレクトされることを確認
+    assert_redirected_to root_path
+
+    # フラッシュメッセージを確認
+    follow_redirect!
+    assert_equal I18n.t("flash.users.already_logged_in"), flash[:alert]
+  end
+
+  test "authenticated user cannot create new user" do
+    # ログインする
+    sign_in_as(@user, password: "password")
+    assert_redirected_to root_url
+
+    # 新しいユーザーを作成しようとする
+    assert_no_difference "User.count" do
+      post users_path, params: {
+        user: {
+          name: "New User",
+          email: "newuser@example.com",
+          password: "password",
+          password_confirmation: "password",
+          is_company: false
+        }
+      }
+    end
+
+    # rootにリダイレクトされることを確認
+    assert_redirected_to root_path
+  end
 end


### PR DESCRIPTION
This pull request improves user authentication flow by preventing logged-in users from accessing the signup page or creating new accounts, and adds corresponding tests and localization. The main changes are grouped below:

Access control enhancements:

* Added a `redirect_if_authenticated` before_action to `UsersController` to redirect authenticated users away from the signup (`new`) and account creation (`create`) actions, showing an alert message. [[1]](diffhunk://#diff-cfdccd0a9d5df5a43aaad2a35d36ebbe187c52ad5fdc9846fa189d04537adb6eR4) [[2]](diffhunk://#diff-cfdccd0a9d5df5a43aaad2a35d36ebbe187c52ad5fdc9846fa189d04537adb6eR64-R70)

Localization updates:

* Added a new Japanese flash message `already_logged_in` for the alert shown when a logged-in user tries to access the signup page.

Testing improvements:

* Added integration tests to verify that authenticated users cannot access the signup page or create new users, including checks for redirection and flash messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - ログイン済みユーザーがサインアップ画面や新規登録処理にアクセスした際、トップページへリダイレクトし、アラートを表示。
- バグ修正
  - 認証済み状態でのサインアップ動線をブロックし、不正な重複登録を防止。
- 翻訳
  - 日本語のアラートメッセージ「既にログインしています。」を追加。
- テスト
  - ログイン済みユーザーがサインアップページへアクセスできないこと、および新規ユーザー作成が実行されないことを検証する統合テストを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->