### PR TITLE
ユーザー設定モデルの追加とデフォルト設定の自動生成

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,6 @@
-When performing a code review, respond in Japanese.
+コードレビューの際は、日本語で対応すること。
 
-マイグレーションファイルを作成する場合は、`rails generate migration` コマンドを使用してください。
+rails のファイルを作成する際には、必ず rails のコマンドを通して作成してください。
+
+-   例: `rails generate model User name:string email:string`
+-   例: `rails generate controller Users index show`

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,10 +2,25 @@ class User < ApplicationRecord
   has_secure_password
 
   has_many :sessions, dependent: :destroy
+  has_one :user_setting, dependent: :destroy
 
   validates :name, presence: true
   normalizes :email, with: ->(email) { email.strip.downcase }
   validates :email, presence: true, uniqueness: true
 
   has_many :written_reviews, class_name: "Review", foreign_key: "reviewer_id", dependent: :destroy
+
+  # ユーザー作成時に設定を自動生成
+  after_create :create_default_settings
+
+  # 設定へのショートカットメソッド
+  def setting(key)
+    user_setting&.get(key) || UserSetting::DEFAULT_SETTINGS[key.to_sym]
+  end
+
+  private
+
+  def create_default_settings
+    create_user_setting(settings: UserSetting::DEFAULT_SETTINGS)
+  end
 end

--- a/app/models/user_setting.rb
+++ b/app/models/user_setting.rb
@@ -11,6 +11,8 @@ class UserSetting < ApplicationRecord
     bt_characteristic_uuid: "3d8828a9-e983-4235-a25a-25b741e81893"
   }.freeze
 
+  READONLY_KEYS = %w[bt_service_uuid bt_characteristic_uuid].freeze
+
   after_initialize :set_default_settings, if: :new_record?
 
   # 設定の取得（デフォルト値とマージ）

--- a/app/models/user_setting.rb
+++ b/app/models/user_setting.rb
@@ -21,13 +21,14 @@ class UserSetting < ApplicationRecord
   def set(key, value)
     self.settings ||= {}
     self.settings = settings.merge(key.to_s => value)
-    save
+    save!
   end
 
   def update_settings(new_settings)
     self.settings ||= {}
-    self.settings = settings.merge(new_settings.stringify_keys)
-    save
+    filtered_settings = new_settings.stringify_keys.except(*READONLY_KEYS)
+    self.settings = settings.merge(filtered_settings)
+    save!
   end
 
   def bod_upper_limit

--- a/app/models/user_setting.rb
+++ b/app/models/user_setting.rb
@@ -1,0 +1,70 @@
+class UserSetting < ApplicationRecord
+  belongs_to :user
+
+  serialize :settings, coder: JSON
+
+  DEFAULT_SETTINGS = {
+    bod_upper_limit: 5000,
+    location: nil,
+    average_estimated_value: nil,
+    bt_service_uuid: "0696b0a8-b883-4d89-a87c-1f5d5e78d0e9",
+    bt_characteristic_uuid: "3d8828a9-e983-4235-a25a-25b741e81893"
+  }.freeze
+
+  after_initialize :set_default_settings, if: :new_record?
+
+  # 設定の取得（デフォルト値とマージ）
+  def get(key)
+    (settings || {}).fetch(key.to_s, DEFAULT_SETTINGS[key.to_sym])
+  end
+
+  def set(key, value)
+    self.settings ||= {}
+    self.settings = settings.merge(key.to_s => value)
+    save
+  end
+
+  def update_settings(new_settings)
+    self.settings ||= {}
+    self.settings = settings.merge(new_settings.stringify_keys)
+    save
+  end
+
+  def bod_upper_limit
+    get(:bod_upper_limit)
+  end
+
+  def bod_upper_limit=(value)
+    set(:bod_upper_limit, value.to_i)
+  end
+
+  def location
+    get(:location)
+  end
+
+  def location=(value)
+    set(:location, value)
+  end
+
+  def average_estimated_value
+    get(:average_estimated_value)
+  end
+
+  def average_estimated_value=(value)
+    set(:average_estimated_value, value)
+  end
+
+  def bt_service_uuid
+    get(:bt_service_uuid)
+  end
+
+  def bt_characteristic_uuid
+    get(:bt_characteristic_uuid)
+  end
+
+  private
+
+  def set_default_settings
+    self.settings ||= DEFAULT_SETTINGS.stringify_keys
+  end
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,37 +5,36 @@
 #   gem "sqlite3"
 #
 default: &default
-  adapter: sqlite3
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
+    adapter: sqlite3
+    pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+    timeout: 5000
 
 development:
-  <<: *default
-  database: storage/development.sqlite3
+    <<: *default
+    database: storage/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
-  database: storage/test.sqlite3
-
+    <<: *default
+    database: storage/test.sqlite3
 
 # Store production database in the storage/ directory, which by default
 # is mounted as a persistent Docker volume in config/deploy.yml.
 production:
-  primary:
-    <<: *default
-    database: storage/production.sqlite3
-  cache:
-    <<: *default
-    database: storage/production_cache.sqlite3
-    migrations_paths: db/cache_migrate
-  queue:
-    <<: *default
-    database: storage/production_queue.sqlite3
-    migrations_paths: db/queue_migrate
-  cable:
-    <<: *default
-    database: storage/production_cable.sqlite3
-    migrations_paths: db/cable_migrate
+    primary:
+        <<: *default
+        database: storage/production.sqlite3
+    cache:
+        <<: *default
+        database: storage/production_cache.sqlite3
+        migrations_paths: db/cache_migrate
+    queue:
+        <<: *default
+        database: storage/production_queue.sqlite3
+        migrations_paths: db/queue_migrate
+    cable:
+        <<: *default
+        database: storage/production_cable.sqlite3
+        migrations_paths: db/cable_migrate

--- a/db/migrate/20251009084435_create_user_settings.rb
+++ b/db/migrate/20251009084435_create_user_settings.rb
@@ -1,0 +1,10 @@
+class CreateUserSettings < ActiveRecord::Migration[8.0]
+  def change
+    create_table :user_settings do |t|
+      t.references :user, null: false, foreign_key: true, index: { unique: true }
+      t.text :settings, null: false, default: "{}"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_08_141529) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_09_084435) do
   create_table "measurements", force: :cascade do |t|
     t.float "turbidity"
     t.float "predicted_bod"
@@ -58,6 +58,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_08_141529) do
     t.index ["name", "address"], name: "index_stores_on_name_and_address", unique: true
   end
 
+  create_table "user_settings", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.text "settings", default: "{}", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_user_settings_on_user_id", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "email"
@@ -72,4 +80,5 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_08_141529) do
   add_foreign_key "reviews", "stores", column: "reviewee_id"
   add_foreign_key "reviews", "users", column: "reviewer_id"
   add_foreign_key "sessions", "users"
+  add_foreign_key "user_settings", "users"
 end

--- a/test/fixtures/user_settings.yml
+++ b/test/fixtures/user_settings.yml
@@ -1,0 +1,4 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# User settingsはafter_createで自動生成されるため、fixtureは空にします
+# テストで必要な場合は直接作成してください

--- a/test/models/user_setting_test.rb
+++ b/test/models/user_setting_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+class UserSettingTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:alice)
+  end
+
+  test "user should have default settings after creation" do
+    new_user = User.create!(name: "Test User", email: "test@example.com", password: "password")
+
+    assert_not_nil new_user.user_setting
+    assert_equal 5000, new_user.user_setting.bod_upper_limit
+    assert_nil new_user.user_setting.location
+    assert_nil new_user.user_setting.average_estimated_value
+    assert_equal "0696b0a8-b883-4d89-a87c-1f5d5e78d0e9", new_user.user_setting.bt_service_uuid
+    assert_equal "3d8828a9-e983-4235-a25a-25b741e81893", new_user.user_setting.bt_characteristic_uuid
+  end
+
+  test "can update individual settings" do
+    setting = @user.user_setting || @user.create_user_setting
+
+    setting.bod_upper_limit = 6000
+    assert_equal 6000, setting.bod_upper_limit
+
+    setting.location = "Tokyo"
+    assert_equal "Tokyo", setting.location
+
+    setting.average_estimated_value = 4500
+    assert_equal 4500, setting.average_estimated_value
+  end
+
+  test "can update multiple settings at once" do
+    setting = @user.user_setting || @user.create_user_setting
+
+    setting.update_settings(
+      bod_upper_limit: 7000,
+      location: "Osaka",
+      average_estimated_value: 5000
+    )
+
+    assert_equal 7000, setting.bod_upper_limit
+    assert_equal "Osaka", setting.location
+    assert_equal 5000, setting.average_estimated_value
+  end
+
+  test "bluetooth UUIDs should not be changeable" do
+    setting = @user.user_setting || @user.create_user_setting
+
+    # これらは読み取り専用
+    assert_equal "0696b0a8-b883-4d89-a87c-1f5d5e78d0e9", setting.bt_service_uuid
+    assert_equal "3d8828a9-e983-4235-a25a-25b741e81893", setting.bt_characteristic_uuid
+  end
+
+  test "settings should be accessible via user shortcut method" do
+    new_user = User.create!(name: "Test User 2", email: "test2@example.com", password: "password")
+
+    assert_equal 5000, new_user.setting(:bod_upper_limit)
+    assert_nil new_user.setting(:location)
+  end
+
+  test "one user setting per user" do
+    # まず@userにuser_settingを作成
+    @user.create_user_setting unless @user.user_setting
+
+    # 同じuserに対して2つ目のuser_settingを作成しようとするとunique制約エラーになる
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      UserSetting.create!(user: @user)
+    end
+  end
+end


### PR DESCRIPTION
マイグレーションによってユーザー設定モデルを実装し、ユーザー作成時にデフォルト設定を自動生成できるようにする。機能を保証するためのテストとともに、設定を取得および更新するためのメソッドを含める。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ユーザーごとの設定管理を追加し、新規ユーザーにデフォルト設定を自動適用。
  - BOD上限値、所在地、平均推定値、Bluetoothサービス/キャラクタリスティックUUIDを保存・更新可能に。
  - ユーザープロフィールから設定値を簡単に参照できる導線を追加。
  - 各ユーザーは設定を1件に制約し、重複を防止（DBマイグレーションで user_settings テーブルを追加）。
- **テスト**
  - 設定の初期値・更新・読み取り・一意性を検証するテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->