### PR TITLE
Add methods for retrieving and creating user settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,158 @@ bin/kamal deploy
 
 ## 開発メモ
 
+## ユーザー設定（UserSetting）の使い方
+
+### 📝 概要
+
+各ユーザーは個別の設定を持ち、BOD上限値、位置情報、Bluetooth UUIDなどを管理できます。
+
+### 🔧 基本的な使い方
+
+#### ログイン中のユーザーの設定を取得
+
+コントローラーまたはビューで以下のように使用します：
+
+```ruby
+# コントローラー・ビューどちらでも使用可能
+current_user_setting.bod_upper_limit          # BOD上限値（デフォルト: 5000）
+current_user_setting.location                 # 位置情報
+current_user_setting.average_estimated_value  # 平均推定値
+current_user_setting.bt_service_uuid          # Bluetooth Service UUID（読み取り専用）
+current_user_setting.bt_characteristic_uuid   # Bluetooth Characteristic UUID（読み取り専用）
+```
+
+#### Userモデル経由で取得
+
+```ruby
+# 設定オブジェクトを取得
+user = User.find(1)
+setting = user.setting
+
+# ショートカットメソッドを使用
+user.bod_upper_limit          # 5000
+user.location                 # nil または設定値
+user.bt_service_uuid          # Bluetooth UUID
+```
+
+### ⚙️ 設定値の更新
+
+#### 個別に更新
+
+```ruby
+setting = current_user_setting
+setting.bod_upper_limit = 6000
+setting.location = "Tokyo"
+setting.average_estimated_value = 4500
+```
+
+#### 一括更新
+
+```ruby
+setting = current_user_setting
+setting.update_settings(
+  bod_upper_limit: 7000,
+  location: "Osaka",
+  average_estimated_value: 5000
+)
+```
+
+#### コントローラーでの更新例
+
+```ruby
+class UserSettingsController < ApplicationController
+  before_action :authenticate_user!
+
+  def update
+    if current_user_setting.update_settings(user_setting_params)
+      redirect_to root_path, notice: '設定を更新しました'
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_setting_params
+    params.require(:user_setting).permit(:bod_upper_limit, :location, :average_estimated_value)
+  end
+end
+```
+
+### 📦 デフォルト値
+
+ユーザー作成時に自動的に以下のデフォルト値が設定されます：
+
+| 設定項目                  | デフォルト値                             | 変更可能 |
+| ------------------------- | ---------------------------------------- | -------- |
+| `bod_upper_limit`         | `5000`                                   | ✅        |
+| `location`                | `nil`                                    | ✅        |
+| `average_estimated_value` | `nil`                                    | ✅        |
+| `bt_service_uuid`         | `"0696b0a8-b883-4d89-a87c-1f5d5e78d0e9"` | ❌        |
+| `bt_characteristic_uuid`  | `"3d8828a9-e983-4235-a25a-25b741e81893"` | ❌        |
+
+### 🔒 読み取り専用設定
+
+Bluetooth UUIDは読み取り専用で、`update_settings`メソッドでも変更できません：
+
+```ruby
+# これらは常に読み取り専用
+current_user_setting.bt_service_uuid          # 変更不可
+current_user_setting.bt_characteristic_uuid   # 変更不可
+
+# update_settingsでも無視される
+setting.update_settings(bt_service_uuid: "new-value")  # 無視される
+```
+
+### 🎨 ビューでの使用例
+
+```erb
+<%# app/views/dashboard/index.html.erb %>
+<div class="user-settings">
+  <p>BOD上限値: <%= current_user_setting.bod_upper_limit %></p>
+  <p>位置情報: <%= current_user_setting.location || '未設定' %></p>
+
+  <% if current_user_setting.average_estimated_value %>
+    <p>平均推定値: <%= current_user_setting.average_estimated_value %></p>
+  <% end %>
+</div>
+```
+
+### 🔍 getメソッドの使用
+
+シンボルまたは文字列で設定値を取得できます：
+
+```ruby
+setting = current_user_setting
+
+setting.get(:bod_upper_limit)           # 5000
+setting.get("location")                 # nil または設定値
+setting.get(:average_estimated_value)   # nil または設定値
+```
+
+### ⚠️ 注意事項
+
+1. **自動作成**: ユーザー作成時に設定は自動的に作成されます
+2. **nil安全**: `current_user_setting`は未ログイン時に`nil`を返します
+3. **永続化**: 設定値の変更は明示的に保存する必要があります
+   ```ruby
+   setting.bod_upper_limit = 6000  # これだけでは保存されない
+   # または
+   setting.update_settings(bod_upper_limit: 6000)  # これは自動保存
+   ```
+
+### 🧪 テスト
+
+```ruby
+# test/models/user_setting_test.rb
+test "can update individual settings" do
+  setting = @user.setting
+
+  setting.bod_upper_limit = 6000
+  assert_equal 6000, setting.bod_upper_limit
+end
+```
+
 ## 開発サーバーの立ち上げ方
 
 開発サーバーを立ち上げるには、以下のコマンドを実行します：
@@ -108,5 +260,28 @@ $ rails db:test:prepare
 ```ruby
 rails c
 undo(dev)> ActiveRecord::Base.connection.tables
-=> ["stores", "reviews", "measurements", "sessions", "schema_migrations", "ar_internal_metadata", "users"]
+=> ["stores", "reviews", "measurements", "sessions", "user_settings", "schema_migrations", "ar_internal_metadata", "users"]
 ```
+
+## 主要なモデルとリレーション
+
+### User（ユーザー）
+- `has_many :sessions` - セッション管理
+- `has_one :user_setting` - ユーザー設定（1対1）
+- `has_many :written_reviews` - 書いたレビュー
+
+### UserSetting（ユーザー設定）
+- `belongs_to :user` - 所属するユーザー
+- JSON形式で柔軟な設定を保存
+- デフォルト値を自動設定
+
+### Review（レビュー）
+- `belongs_to :store` - レビュー対象の店舗
+- `belongs_to :reviewer` (User) - レビューを書いたユーザー
+
+### Measurement（測定データ）
+- ユーザーの測定記録を管理
+
+### Store（店舗）
+- `has_many :reviews` - 店舗に対するレビュー
+- うどん店の情報を管理

--- a/README.md
+++ b/README.md
@@ -181,11 +181,11 @@ setting.get(:average_estimated_value)   # nil または設定値
 
 1. **自動作成**: ユーザー作成時に設定は自動的に作成されます
 2. **nil安全**: `current_user_setting`は未ログイン時に`nil`を返します
-3. **永続化**: 設定値の変更は明示的に保存する必要があります
+3. **永続化**: 個別のセッターメソッド（`bod_upper_limit=`など）は自動的に保存されます
    ```ruby
-   setting.bod_upper_limit = 6000  # これだけでは保存されない
-   # または
-   setting.update_settings(bod_upper_limit: 6000)  # これは自動保存
+   setting.bod_upper_limit = 6000  # 自動的に保存される
+   # または一括更新  
+   setting.update_settings(bod_upper_limit: 6000)  # 複数の設定を一度に更新
    ```
 
 ### 🧪 テスト

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,18 @@ class ApplicationController < ActionController::Base
   include Authentication
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  helper_method :current_user_setting
+
+  private
+
+  # ユーザーの設定オブジェクトを取得（なければ作成）
+  #
+  # @return [UserSetting, nil] ログインしていれば設定オブジェクト、していなければnil
+  # @note 存在チェックと作成をまとめて行うため、頻繁に呼び出しても問題ない
+  def current_user_setting
+    return nil unless user_signed_in?
+
+    @current_user_setting ||= current_user.user_setting || current_user.create_user_setting
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,9 +13,30 @@ class User < ApplicationRecord
   # ユーザー作成時に設定を自動生成
   after_create :create_default_settings
 
-  # 設定へのショートカットメソッド
-  def setting(key)
-    user_setting&.get(key) || UserSetting::DEFAULT_SETTINGS[key.to_sym]
+  # 設定オブジェクトを取得（なければ作成）
+  def setting
+    user_setting || create_user_setting
+  end
+
+  # 設定値へのショートカット
+  def bod_upper_limit
+    setting.bod_upper_limit
+  end
+
+  def location
+    setting.location
+  end
+
+  def average_estimated_value
+    setting.average_estimated_value
+  end
+
+  def bt_service_uuid
+    setting.bt_service_uuid
+  end
+
+  def bt_characteristic_uuid
+    setting.bt_characteristic_uuid
   end
 
   private

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class ApplicationControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:alice)
+  end
+
+  test "current_user_setting returns nil when not logged in" do
+    get root_url
+    # ログインしていない場合はnilを返す（ビューで確認）
+    assert_response :success
+  end
+
+  test "current_user_setting returns user setting when logged in" do
+    # ログイン
+    post signin_path, params: { email: @user.email, password: "password" }
+
+    # ログイン後のページにアクセス
+    get root_url
+    assert_response :success
+
+    # current_user_settingがヘルパーメソッドとして使える
+    # （実際の動作確認は統合テストで行う）
+  end
+
+  test "current_user_setting creates setting if not exists" do
+    # 新しいユーザーを作成（設定も自動作成される）
+    new_user = User.create!(name: "New User", email: "new@example.com", password: "password")
+
+    # ログイン
+    post signin_path, params: { email: new_user.email, password: "password" }
+
+    # 設定が存在することを確認
+    assert_not_nil new_user.reload.user_setting
+    assert_equal 5000, new_user.user_setting.bod_upper_limit
+  end
+end

--- a/test/models/user_setting_test.rb
+++ b/test/models/user_setting_test.rb
@@ -54,8 +54,19 @@ class UserSettingTest < ActiveSupport::TestCase
   test "settings should be accessible via user shortcut method" do
     new_user = User.create!(name: "Test User 2", email: "test2@example.com", password: "password")
 
-    assert_equal 5000, new_user.setting(:bod_upper_limit)
-    assert_nil new_user.setting(:location)
+    # settingメソッドは設定オブジェクトを返す
+    assert_instance_of UserSetting, new_user.setting
+    assert_equal 5000, new_user.setting.bod_upper_limit
+    assert_nil new_user.setting.location
+  end
+
+  test "get method returns default values" do
+    setting = @user.user_setting || @user.create_user_setting
+
+    # デフォルト値が返される
+    assert_equal 5000, setting.get(:bod_upper_limit)
+    assert_nil setting.get(:location)
+    assert_nil setting.get(:average_estimated_value)
   end
 
   test "one user setting per user" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,48 @@
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @user = users(:alice)
+  end
+
+  test "user should have setting method that returns user_setting" do
+    # user_settingが存在しない場合は作成される
+    setting = @user.setting
+    assert_not_nil setting
+    assert_instance_of UserSetting, setting
+  end
+
+  test "user setting shortcut methods work correctly" do
+    # ユーザー作成時に自動的に設定が作成される
+    new_user = User.create!(name: "Test User", email: "test@example.com", password: "password")
+
+    assert_equal 5000, new_user.bod_upper_limit
+    assert_nil new_user.location
+    assert_nil new_user.average_estimated_value
+    assert_equal "0696b0a8-b883-4d89-a87c-1f5d5e78d0e9", new_user.bt_service_uuid
+    assert_equal "3d8828a9-e983-4235-a25a-25b741e81893", new_user.bt_characteristic_uuid
+  end
+
+  test "user setting shortcut methods reflect changes" do
+    user = User.create!(name: "Test User 2", email: "test2@example.com", password: "password")
+
+    user.setting.bod_upper_limit = 8000
+    user.setting.location = "Kyoto"
+
+    assert_equal 8000, user.bod_upper_limit
+    assert_equal "Kyoto", user.location
+  end
+
+  test "setting method creates user_setting if not exists" do
+    # user_settingを削除
+    @user.user_setting&.destroy
+    @user.reload
+
+    assert_nil @user.user_setting
+
+    # settingメソッドを呼ぶと作成される
+    setting = @user.setting
+    assert_not_nil setting
+    assert_equal @user.id, setting.user_id
+  end
 end


### PR DESCRIPTION
Introduce methods to manage user settings, including retrieval and updates, along with corresponding tests to ensure functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - ビュー/コントローラから current_user_setting を直接利用可能に（未作成時は自動生成）。
  - User に設定用ショートカットアクセサ（bod_upper_limit、location、average_estimated_value、bt_service_uuid、bt_characteristic_uuid）を追加。
- ドキュメント
  - UserSetting の使い方、既定値、読み取り専用項目、コントローラ/ビュー例、永続化・nil安全性等を README に追記。
- テスト
  - 自動生成・既定値取得・ショートカットアクセサの振る舞いを検証するテストを追加・更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->