### PR TITLE
Add store and udon share management features

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,12 +179,12 @@ setting.get(:average_estimated_value)   # nil または設定値
 
 ### ⚠️ 注意事項
 
-1. **自動作成**: ユーザー作成時に設定は自動的に作成されます
+1. **自動作成**: ユーザー作成時に設定は自動的に作成されます（規定値が読み込まれるのはユーザー初回ログイン時です）
 2. **nil安全**: `current_user_setting`は未ログイン時に`nil`を返します
 3. **永続化**: 個別のセッターメソッド（`bod_upper_limit=`など）は自動的に保存されます
    ```ruby
    setting.bod_upper_limit = 6000  # 自動的に保存される
-   # または一括更新  
+   # または一括更新
    setting.update_settings(bod_upper_limit: 6000)  # 複数の設定を一度に更新
    ```
 

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -44,7 +44,7 @@ $radius-lg: 12px;
 
 .admin {
     &__container {
-        max-width: 1400px;
+        max-width: 1600px;
         margin: 0 auto;
         padding: 2rem 1rem;
     }
@@ -57,14 +57,13 @@ $radius-lg: 12px;
     }
 
     &__title {
-        font-size: 2rem;
+        font-size: 1.6rem;
         font-weight: 700;
         color: map.get($palette, "dark");
         margin: 0;
 
         &::before {
-            content: "🏪 ";
-            margin-right: 0.5rem;
+            content: "🏪";
         }
     }
 
@@ -122,6 +121,7 @@ $radius-lg: 12px;
         &--success {
             background: linear-gradient(135deg, #10b981, #059669);
             color: map.get($palette, "light");
+            width: 30%;
 
             &:hover {
                 background: linear-gradient(135deg, #059669, #047857);

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1,0 +1,575 @@
+// Admin Panel Styles
+
+@use "sass:color";
+@use "sass:map";
+
+// main.scssからパレットをインポート
+$palette: (
+    "primary": #f28705,
+    "secondary": #f29f05,
+    "accent": #f23030,
+    "highlight": #f2cb05,
+    "dark": #301b01,
+    "light": #ffffff,
+    "success": #00cc00,
+    "danger": #ff0000,
+    "info": #3b82f6,
+    "warning": #f59e0b,
+    "gray": #666666,
+    "gray-light": #f3f4f6,
+    "gray-medium": #9ca3af,
+    "gray-dark": #4b5563,
+);
+
+$radius-sm: 4px;
+$radius-md: 8px;
+$radius-lg: 12px;
+
+@mixin flexbox(
+    $justify: flex-start,
+    $align: stretch,
+    $direction: row,
+    $gap: 0
+) {
+    display: flex;
+    justify-content: $justify;
+    align-items: $align;
+    flex-direction: $direction;
+    gap: $gap;
+}
+
+//================================================
+// 管理画面コンテナ
+//================================================
+
+.admin {
+    &__container {
+        max-width: 1400px;
+        margin: 0 auto;
+        padding: 2rem 1rem;
+    }
+
+    &__header {
+        @include flexbox($justify: space-between, $align: center);
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 3px solid map.get($palette, "primary");
+    }
+
+    &__title {
+        font-size: 2rem;
+        font-weight: 700;
+        color: map.get($palette, "dark");
+        margin: 0;
+
+        &::before {
+            content: "🏪 ";
+            margin-right: 0.5rem;
+        }
+    }
+
+    &__subtitle {
+        font-size: 1.2rem;
+        font-weight: 600;
+        color: map.get($palette, "dark");
+        margin: 1.5rem 0 1rem;
+    }
+
+    //================================================
+    // ボタンスタイル
+    //================================================
+
+    &__btn {
+        display: inline-block;
+        padding: 0.75rem 1.5rem;
+        border-radius: $radius-md;
+        font-weight: 600;
+        font-size: 1rem;
+        text-decoration: none;
+        text-align: center;
+        cursor: pointer;
+        border: none;
+        transition: all 0.2s ease;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+
+        &:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+        }
+
+        &:active {
+            transform: translateY(0);
+            box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+        }
+
+        &--primary {
+            background: linear-gradient(
+                135deg,
+                map.get($palette, "primary"),
+                color.scale(map.get($palette, "primary"), $lightness: -10%)
+            );
+            color: map.get($palette, "light");
+
+            &:hover {
+                background: linear-gradient(
+                    135deg,
+                    color.scale(map.get($palette, "primary"), $lightness: -10%),
+                    color.scale(map.get($palette, "primary"), $lightness: -20%)
+                );
+            }
+        }
+
+        &--success {
+            background: linear-gradient(135deg, #10b981, #059669);
+            color: map.get($palette, "light");
+
+            &:hover {
+                background: linear-gradient(135deg, #059669, #047857);
+            }
+        }
+
+        &--info {
+            background: linear-gradient(
+                135deg,
+                map.get($palette, "info"),
+                #2563eb
+            );
+            color: map.get($palette, "light");
+
+            &:hover {
+                background: linear-gradient(135deg, #2563eb, #1d4ed8);
+            }
+        }
+
+        &--danger {
+            background: linear-gradient(135deg, #ef4444, #dc2626);
+            color: map.get($palette, "light");
+
+            &:hover {
+                background: linear-gradient(135deg, #dc2626, #b91c1c);
+            }
+        }
+
+        &--secondary {
+            background: linear-gradient(
+                135deg,
+                map.get($palette, "gray-medium"),
+                map.get($palette, "gray-dark")
+            );
+            color: map.get($palette, "light");
+
+            &:hover {
+                background: linear-gradient(
+                    135deg,
+                    map.get($palette, "gray-dark"),
+                    #374151
+                );
+            }
+        }
+
+        &--disabled {
+            background: map.get($palette, "gray-light") !important;
+            color: map.get($palette, "gray-medium") !important;
+            cursor: not-allowed !important;
+            box-shadow: none !important;
+
+            &:hover {
+                transform: none !important;
+                box-shadow: none !important;
+            }
+        }
+
+        &--small {
+            padding: 0.4rem 0.8rem;
+            font-size: 0.875rem;
+        }
+    }
+
+    //================================================
+    // カードグリッド
+    //================================================
+
+    &__grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+        gap: 1.5rem;
+        margin-top: 1.5rem;
+
+        @media (max-width: 768px) {
+            grid-template-columns: 1fr;
+        }
+    }
+
+    &__empty-state {
+        background: linear-gradient(135deg, #fef3c7, #fde68a);
+        border: 2px solid map.get($palette, "warning");
+        border-radius: $radius-lg;
+        padding: 3rem 2rem;
+        text-align: center;
+
+        &-icon {
+            font-size: 4rem;
+            margin-bottom: 1rem;
+        }
+
+        &-text {
+            font-size: 1.25rem;
+            color: map.get($palette, "dark");
+            margin-bottom: 1.5rem;
+            font-weight: 500;
+        }
+    }
+
+    //================================================
+    // 店舗カード
+    //================================================
+
+    &__store-card {
+        background: map.get($palette, "light");
+        border: 2px solid map.get($palette, "gray-light");
+        border-radius: $radius-lg;
+        padding: 1.5rem;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        transition: all 0.3s ease;
+
+        &:hover {
+            border-color: map.get($palette, "primary");
+            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+            transform: translateY(-2px);
+        }
+    }
+
+    &__store-header {
+        @include flexbox($justify: space-between, $align: flex-start);
+        margin-bottom: 1rem;
+        padding-bottom: 1rem;
+        border-bottom: 2px solid map.get($palette, "gray-light");
+    }
+
+    &__store-info {
+        flex: 1;
+    }
+
+    &__store-name {
+        font-size: 1.4rem;
+        font-weight: 700;
+        color: map.get($palette, "dark");
+        margin: 0 0 0.5rem 0;
+        line-height: 1.3;
+    }
+
+    &__store-address {
+        font-size: 0.9rem;
+        color: map.get($palette, "gray");
+        margin: 0;
+        line-height: 1.4;
+
+        &::before {
+            content: "📍 ";
+        }
+    }
+
+    &__store-badge {
+        display: inline-block;
+        padding: 0.3rem 0.8rem;
+        border-radius: $radius-sm;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+
+        &--eco {
+            background: linear-gradient(135deg, #d1fae5, #a7f3d0);
+            color: #065f46;
+            border: 1px solid #6ee7b7;
+        }
+
+        &--share {
+            background: linear-gradient(135deg, #fef3c7, #fde68a);
+            color: #92400e;
+            border: 1px solid #fbbf24;
+        }
+    }
+
+    //================================================
+    // シェア情報ボックス
+    //================================================
+
+    &__share-box {
+        background: linear-gradient(135deg, #ecfdf5, #d1fae5);
+        border: 2px solid #6ee7b7;
+        border-radius: $radius-md;
+        padding: 1rem;
+        margin-bottom: 1rem;
+
+        &--empty {
+            background: map.get($palette, "gray-light");
+            border-color: #d1d5db;
+        }
+    }
+
+    &__share-title {
+        font-size: 0.95rem;
+        font-weight: 600;
+        color: #065f46;
+        margin: 0 0 0.5rem 0;
+
+        &::before {
+            content: "🎁 ";
+        }
+    }
+
+    &__share-description {
+        font-size: 0.85rem;
+        color: #047857;
+        margin: 0 0 0.5rem 0;
+        line-height: 1.4;
+    }
+
+    &__share-time {
+        font-size: 0.8rem;
+        color: #059669;
+        margin: 0;
+
+        &::before {
+            content: "⏰ ";
+        }
+    }
+
+    &__share-empty {
+        font-size: 0.9rem;
+        color: map.get($palette, "gray");
+        margin: 0;
+        text-align: center;
+    }
+
+    //================================================
+    // ボタングループ
+    //================================================
+
+    &__button-group {
+        @include flexbox($gap: 0.5rem);
+        margin-top: 1rem;
+
+        &--vertical {
+            flex-direction: column;
+        }
+    }
+
+    &__button-flex {
+        flex: 1;
+    }
+
+    //================================================
+    // 店舗選択リスト
+    //================================================
+
+    &__store-list {
+        display: grid;
+        gap: 1rem;
+        margin-top: 1.5rem;
+    }
+
+    &__store-item {
+        @include flexbox($justify: space-between, $align: center);
+        padding: 1.25rem;
+        background: map.get($palette, "light");
+        border: 2px solid map.get($palette, "gray-light");
+        border-radius: $radius-md;
+        transition: all 0.2s ease;
+
+        &:hover {
+            border-color: map.get($palette, "secondary");
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.08);
+        }
+
+        &--operated {
+            background: linear-gradient(135deg, #fef3c7, #fde68a);
+            border-color: map.get($palette, "warning");
+        }
+    }
+
+    &__store-item-info {
+        flex: 1;
+    }
+
+    &__store-item-name {
+        font-size: 1.1rem;
+        font-weight: 600;
+        color: map.get($palette, "dark");
+        margin: 0 0 0.3rem 0;
+    }
+
+    &__store-item-address {
+        font-size: 0.85rem;
+        color: map.get($palette, "gray");
+        margin: 0;
+    }
+
+    &__store-item-status {
+        font-size: 0.8rem;
+        font-weight: 600;
+        color: map.get($palette, "warning");
+        margin-top: 0.3rem;
+
+        &::before {
+            content: "✓ ";
+        }
+    }
+
+    //================================================
+    // フォームスタイル
+    //================================================
+
+    &__form {
+        max-width: 600px;
+        margin: 2rem auto;
+        background: map.get($palette, "light");
+        padding: 2rem;
+        border-radius: $radius-lg;
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+    }
+
+    &__form-header {
+        background: linear-gradient(135deg, map.get($palette, "info"), #2563eb);
+        color: map.get($palette, "light");
+        padding: 1.25rem;
+        border-radius: $radius-md;
+        margin-bottom: 1.5rem;
+    }
+
+    &__form-store-name {
+        font-size: 1.3rem;
+        font-weight: 700;
+        margin: 0 0 0.3rem 0;
+    }
+
+    &__form-store-address {
+        font-size: 0.9rem;
+        opacity: 0.9;
+        margin: 0;
+    }
+
+    &__form-group {
+        margin-bottom: 1.5rem;
+    }
+
+    &__form-label {
+        display: block;
+        font-weight: 600;
+        font-size: 0.95rem;
+        color: map.get($palette, "dark");
+        margin-bottom: 0.5rem;
+
+        &--required::after {
+            content: " *";
+            color: map.get($palette, "danger");
+        }
+
+        &--optional::after {
+            content: " (任意)";
+            font-size: 0.85rem;
+            color: map.get($palette, "gray");
+            font-weight: 400;
+        }
+    }
+
+    &__form-input,
+    &__form-textarea {
+        width: 100%;
+        padding: 0.75rem;
+        border: 2px solid map.get($palette, "gray-light");
+        border-radius: $radius-sm;
+        font-size: 1rem;
+        font-family: inherit;
+        transition: all 0.2s ease;
+
+        &:focus {
+            outline: none;
+            border-color: map.get($palette, "primary");
+            box-shadow: 0 0 0 3px rgba(map.get($palette, "primary"), 0.1);
+        }
+
+        &::placeholder {
+            color: map.get($palette, "gray-medium");
+        }
+    }
+
+    &__form-textarea {
+        resize: vertical;
+        min-height: 100px;
+    }
+
+    &__form-help {
+        font-size: 0.85rem;
+        color: map.get($palette, "gray");
+        margin-top: 0.3rem;
+        display: block;
+    }
+
+    &__form-actions {
+        @include flexbox($gap: 1rem);
+        margin-top: 2rem;
+        padding-top: 1.5rem;
+        border-top: 2px solid map.get($palette, "gray-light");
+    }
+
+    //================================================
+    // エラーメッセージ
+    //================================================
+
+    &__errors {
+        background: linear-gradient(135deg, #fee2e2, #fecaca);
+        border: 2px solid #ef4444;
+        border-radius: $radius-md;
+        padding: 1.25rem;
+        margin-bottom: 1.5rem;
+    }
+
+    &__errors-title {
+        font-size: 1rem;
+        font-weight: 700;
+        color: #991b1b;
+        margin: 0 0 0.75rem 0;
+
+        &::before {
+            content: "⚠️ ";
+        }
+    }
+
+    &__errors-list {
+        list-style-type: disc;
+        padding-left: 1.5rem;
+        margin: 0;
+    }
+
+    &__errors-item {
+        color: #b91c1c;
+        font-size: 0.9rem;
+        margin-bottom: 0.3rem;
+
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
+
+    //================================================
+    // アニメーション
+    //================================================
+
+    @keyframes slideIn {
+        from {
+            opacity: 0;
+            transform: translateY(20px);
+        }
+        to {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    }
+
+    &__store-card,
+    &__store-item {
+        animation: slideIn 0.3s ease-out;
+    }
+}

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -185,6 +185,18 @@ $radius-lg: 12px;
         }
     }
 
+    &__button-group {
+        display: flex;
+        gap: 0.75rem;
+        align-items: center;
+        flex-wrap: wrap;
+    }
+
+    &__button-flex {
+        flex: 1;
+        min-width: 120px;
+    }
+
     //================================================
     // カードグリッド
     //================================================

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -123,7 +123,8 @@ main {
         z-index: map.get($z-layers, "header");
     }
 
-    &__logo {
+    &__logo,
+    &__logo img {
         height: 100%;
     }
 

--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -407,6 +407,33 @@ main {
         &--disappear {
             animation: markerDisappear 0.3s ease-in forwards;
         }
+
+        &-share {
+            position: absolute;
+            top: -24px;
+            left: 50%;
+            transform: translateX(-50%);
+            background-color: map.get($palette, "success");
+            color: map.get($palette, "light");
+            padding: 2px 6px;
+            border-radius: 12px;
+            font-size: 10px;
+            font-weight: 600;
+            white-space: nowrap;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+            @include flexbox($align: center, $gap: 3px);
+
+            &-icon {
+                font-size: 12px;
+                line-height: 1;
+            }
+
+            &-time {
+                font-size: 9px;
+                font-weight: 700;
+                letter-spacing: 0.5px;
+            }
+        }
     }
 
     &__info {

--- a/app/controllers/admin/stores_controller.rb
+++ b/app/controllers/admin/stores_controller.rb
@@ -27,6 +27,12 @@ class Admin::StoresController < ApplicationController
     @store = Store.find(params[:id])
     store_operator = StoreOperator.find_by(user: Current.session.user, store: @store)
 
+    # アクティブなシェアがある場合は削除を防ぐ
+    if @store.active_udon_share.present?
+      redirect_to admin_stores_path, alert: "アクティブなシェアがあるため、運営者から外れることができません。"
+      return
+    end
+
     if store_operator&.destroy
       redirect_to admin_stores_path, notice: "#{@store.name}の運営者から外れました。"
     else

--- a/app/controllers/admin/stores_controller.rb
+++ b/app/controllers/admin/stores_controller.rb
@@ -1,6 +1,7 @@
 class Admin::StoresController < ApplicationController
   layout "admin"
   before_action :require_login
+  rescue_from ActiveRecord::RecordNotFound, with: :store_not_found
 
   def index
     # 運営中の店舗のみを表示
@@ -16,10 +17,16 @@ class Admin::StoresController < ApplicationController
   def add_operator
     @store = Store.find(params[:id])
 
+    # 既に運営者かチェック
+    if StoreOperator.exists?(user: Current.session.user, store: @store)
+      redirect_to admin_stores_path, alert: t("flash.admin.stores.already_operator")
+      return
+    end
+
     if StoreOperator.create(user: Current.session.user, store: @store)
-      redirect_to admin_stores_path, notice: "#{@store.name}の運営者になりました。"
+      redirect_to admin_stores_path, notice: t("flash.admin.stores.operator_added", store_name: @store.name)
     else
-      redirect_to select_admin_stores_path, alert: "運営者の追加に失敗しました。"
+      redirect_to select_admin_stores_path, alert: t("flash.admin.stores.operator_add_failed")
     end
   end
 
@@ -27,16 +34,22 @@ class Admin::StoresController < ApplicationController
     @store = Store.find(params[:id])
     store_operator = StoreOperator.find_by(user: Current.session.user, store: @store)
 
-    # アクティブなシェアがある場合は削除を防ぐ
-    if @store.active_udon_share.present?
-      redirect_to admin_stores_path, alert: "アクティブなシェアがあるため、運営者から外れることができません。"
+    # 運営者でない場合
+    unless store_operator
+      redirect_to admin_stores_path, alert: t("flash.admin.stores.not_operator")
       return
     end
 
-    if store_operator&.destroy
-      redirect_to admin_stores_path, notice: "#{@store.name}の運営者から外れました。"
+    # アクティブなシェアがある場合は削除を防ぐ
+    if @store.active_udon_share.present?
+      redirect_to admin_stores_path, alert: t("flash.admin.stores.has_active_share")
+      return
+    end
+
+    if store_operator.destroy
+      redirect_to admin_stores_path, notice: t("flash.admin.stores.operator_removed", store_name: @store.name)
     else
-      redirect_to admin_stores_path, alert: "運営者の削除に失敗しました。"
+      redirect_to admin_stores_path, alert: t("flash.admin.stores.operator_remove_failed")
     end
   end
 
@@ -44,7 +57,11 @@ class Admin::StoresController < ApplicationController
 
   def require_login
     unless Current.session
-      redirect_to signin_path, alert: "ログインが必要です。"
+      redirect_to signin_path, alert: t("flash.admin.common.login_required")
     end
+  end
+
+  def store_not_found
+    redirect_to admin_stores_path, alert: t("flash.admin.stores.not_found")
   end
 end

--- a/app/controllers/admin/stores_controller.rb
+++ b/app/controllers/admin/stores_controller.rb
@@ -1,4 +1,5 @@
 class Admin::StoresController < ApplicationController
+  layout "admin"
   before_action :require_login
 
   def index

--- a/app/controllers/admin/stores_controller.rb
+++ b/app/controllers/admin/stores_controller.rb
@@ -1,0 +1,43 @@
+class Admin::StoresController < ApplicationController
+  before_action :require_login
+
+  def index
+    # 運営中の店舗のみを表示
+    @operated_stores = Current.session.user.operated_stores.includes(:udon_shares)
+  end
+
+  def select
+    # 店舗を選択できるページ
+    @stores = Store.all.order(:name)
+    @operated_store_ids = Current.session.user.operated_stores.pluck(:id)
+  end
+
+  def add_operator
+    @store = Store.find(params[:id])
+
+    if StoreOperator.create(user: Current.session.user, store: @store)
+      redirect_to admin_stores_path, notice: "#{@store.name}の運営者になりました。"
+    else
+      redirect_to select_admin_stores_path, alert: "運営者の追加に失敗しました。"
+    end
+  end
+
+  def remove_operator
+    @store = Store.find(params[:id])
+    store_operator = StoreOperator.find_by(user: Current.session.user, store: @store)
+
+    if store_operator&.destroy
+      redirect_to admin_stores_path, notice: "#{@store.name}の運営者から外れました。"
+    else
+      redirect_to admin_stores_path, alert: "運営者の削除に失敗しました。"
+    end
+  end
+
+  private
+
+  def require_login
+    unless Current.session
+      redirect_to signin_path, alert: "ログインが必要です。"
+    end
+  end
+end

--- a/app/controllers/admin/udon_shares_controller.rb
+++ b/app/controllers/admin/udon_shares_controller.rb
@@ -2,6 +2,7 @@ class Admin::UdonSharesController < ApplicationController
   before_action :require_login
   before_action :set_store, only: [ :new, :create ]
   before_action :verify_operator, only: [ :new, :create ]
+  before_action :check_active_share, only: [ :new, :create ]
 
   def new
     @udon_share = @store.udon_shares.build
@@ -54,6 +55,12 @@ class Admin::UdonSharesController < ApplicationController
   def verify_operator
     unless @store.operators.include?(Current.session.user)
       redirect_to admin_stores_path, alert: "この店舗の運営者ではありません。"
+    end
+  end
+
+  def check_active_share
+    if @store.active_udon_share
+      redirect_to admin_stores_path, alert: "この店舗には既にアクティブなシェアが存在します。"
     end
   end
 

--- a/app/controllers/admin/udon_shares_controller.rb
+++ b/app/controllers/admin/udon_shares_controller.rb
@@ -4,6 +4,7 @@ class Admin::UdonSharesController < ApplicationController
   before_action :set_store, only: [ :new, :create ]
   before_action :verify_operator, only: [ :new, :create ]
   before_action :check_active_share, only: [ :new, :create ]
+  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
   def new
     @udon_share = @store.udon_shares.build
@@ -15,8 +16,9 @@ class Admin::UdonSharesController < ApplicationController
     if @udon_share.save
       # is_shareフラグを立てる
       @store.update(is_share: true)
-      redirect_to admin_stores_path, notice: "うどんシェアを設定しました。"
+      redirect_to admin_stores_path, notice: t("flash.admin.udon_shares.created")
     else
+      flash.now[:alert] = t("flash.admin.udon_shares.create_failed")
       render :new, status: :unprocessable_entity
     end
   end
@@ -27,25 +29,27 @@ class Admin::UdonSharesController < ApplicationController
 
     # 運営者かチェック
     unless @store.operators.include?(Current.session.user)
-      redirect_to admin_stores_path, alert: "権限がありません。"
+      redirect_to admin_stores_path, alert: t("flash.admin.udon_shares.unauthorized")
       return
     end
 
-    @udon_share.destroy
+    if @udon_share.destroy
+      # アクティブなシェアがなければis_shareフラグを下げる
+      unless @store.udon_shares.active.exists?
+        @store.update(is_share: false)
+      end
 
-    # アクティブなシェアがなければis_shareフラグを下げる
-    unless @store.udon_shares.active.exists?
-      @store.update(is_share: false)
+      redirect_to admin_stores_path, notice: t("flash.admin.udon_shares.destroyed")
+    else
+      redirect_to admin_stores_path, alert: t("flash.admin.udon_shares.destroy_failed")
     end
-
-    redirect_to admin_stores_path, notice: "うどんシェアを削除しました。"
   end
 
   private
 
   def require_login
     unless Current.session
-      redirect_to signin_path, alert: "ログインが必要です。"
+      redirect_to signin_path, alert: t("flash.admin.common.login_required")
     end
   end
 
@@ -55,17 +59,21 @@ class Admin::UdonSharesController < ApplicationController
 
   def verify_operator
     unless @store.operators.include?(Current.session.user)
-      redirect_to admin_stores_path, alert: "この店舗の運営者ではありません。"
+      redirect_to admin_stores_path, alert: t("flash.admin.udon_shares.not_operator")
     end
   end
 
   def check_active_share
     if @store.active_udon_share
-      redirect_to admin_stores_path, alert: "この店舗には既にアクティブなシェアが存在します。"
+      redirect_to admin_stores_path, alert: t("flash.admin.udon_shares.already_exists")
     end
   end
 
   def udon_share_params
     params.require(:udon_share).permit(:item_name, :description, :take_down_time, :photo_url)
+  end
+
+  def record_not_found
+    redirect_to admin_stores_path, alert: t("flash.admin.udon_shares.not_found")
   end
 end

--- a/app/controllers/admin/udon_shares_controller.rb
+++ b/app/controllers/admin/udon_shares_controller.rb
@@ -1,0 +1,63 @@
+class Admin::UdonSharesController < ApplicationController
+  before_action :require_login
+  before_action :set_store, only: [ :new, :create ]
+  before_action :verify_operator, only: [ :new, :create ]
+
+  def new
+    @udon_share = @store.udon_shares.build
+  end
+
+  def create
+    @udon_share = @store.udon_shares.build(udon_share_params)
+
+    if @udon_share.save
+      # is_shareフラグを立てる
+      @store.update(is_share: true)
+      redirect_to admin_stores_path, notice: "うどんシェアを設定しました。"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @udon_share = UdonShare.find(params[:id])
+    @store = @udon_share.store
+
+    # 運営者かチェック
+    unless @store.operators.include?(Current.session.user)
+      redirect_to admin_stores_path, alert: "権限がありません。"
+      return
+    end
+
+    @udon_share.destroy
+
+    # アクティブなシェアがなければis_shareフラグを下げる
+    unless @store.udon_shares.active.exists?
+      @store.update(is_share: false)
+    end
+
+    redirect_to admin_stores_path, notice: "うどんシェアを削除しました。"
+  end
+
+  private
+
+  def require_login
+    unless Current.session
+      redirect_to signin_path, alert: "ログインが必要です。"
+    end
+  end
+
+  def set_store
+    @store = Store.find(params[:store_id])
+  end
+
+  def verify_operator
+    unless @store.operators.include?(Current.session.user)
+      redirect_to admin_stores_path, alert: "この店舗の運営者ではありません。"
+    end
+  end
+
+  def udon_share_params
+    params.require(:udon_share).permit(:item_name, :description, :take_down_time, :photo_url)
+  end
+end

--- a/app/controllers/admin/udon_shares_controller.rb
+++ b/app/controllers/admin/udon_shares_controller.rb
@@ -1,4 +1,5 @@
 class Admin::UdonSharesController < ApplicationController
+  layout "admin"
   before_action :require_login
   before_action :set_store, only: [ :new, :create ]
   before_action :verify_operator, only: [ :new, :create ]

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -26,7 +26,7 @@ class HomeController < ApplicationController
         shareInfo: active_share ? {
           itemName: active_share.item_name,
           description: active_share.description,
-          takeDownTime: active_share.take_down_time.in_time_zone(current_user.time_zone).strftime("%Y-%m-%d %H:%M"),
+          takeDownTime: active_share.take_down_time.in_time_zone("Tokyo").strftime("%Y-%m-%d %H:%M"),
           photoUrl: active_share.photo_url
         } : nil
       }

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,8 +4,10 @@ class HomeController < ApplicationController
   layout "main"
 
   def index
-    @stores_for_map = Store.where.not(lat: nil, lon: nil)
+    @stores_for_map = Store.where.not(lat: nil, lon: nil).includes(:udon_shares)
     @stores_for_map_json = @stores_for_map.map do |store|
+      active_share = store.active_udon_share
+
       {
         id: store.id,
         name: store.name,
@@ -13,8 +15,14 @@ class HomeController < ApplicationController
         lon: store.lon,
         openTime: store.open_time,
         address: store.address,
-        eco: false,
-        foodshare: false
+        eco: store.is_eco,
+        foodshare: store.is_share && active_share.present?,
+        shareInfo: active_share ? {
+          itemName: active_share.item_name,
+          description: active_share.description,
+          takeDownTime: active_share.take_down_time.strftime("%Y-%m-%d %H:%M"),
+          photoUrl: active_share.photo_url
+        } : nil
       }
     end
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -26,7 +26,7 @@ class HomeController < ApplicationController
         shareInfo: active_share ? {
           itemName: active_share.item_name,
           description: active_share.description,
-          takeDownTime: active_share.take_down_time.in_time_zone("Tokyo").strftime("%Y-%m-%d %H:%M"),
+          takeDownTime: active_share.take_down_time.in_time_zone("Tokyo").iso8601,
           photoUrl: active_share.photo_url
         } : nil
       }

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -7,7 +7,6 @@ class HomeController < ApplicationController
     # N+1対策で関連テーブルを事前ロード
     @stores_for_map = Store.where.not(lat: nil, lon: nil)
                            .includes(:udon_shares)
-                           .preload(udon_shares: :store)
 
     # アクティブなシェアをメモリ上でフィルタリング
     @stores_for_map_json = @stores_for_map.map do |store|

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -26,7 +26,7 @@ class HomeController < ApplicationController
         shareInfo: active_share ? {
           itemName: active_share.item_name,
           description: active_share.description,
-          takeDownTime: active_share.take_down_time.strftime("%Y-%m-%d %H:%M"),
+          takeDownTime: active_share.take_down_time.in_time_zone(current_user.time_zone).strftime("%Y-%m-%d %H:%M"),
           photoUrl: active_share.photo_url
         } : nil
       }

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,9 +4,16 @@ class HomeController < ApplicationController
   layout "main"
 
   def index
-    @stores_for_map = Store.where.not(lat: nil, lon: nil).includes(:udon_shares)
+    # N+1対策で関連テーブルを事前ロード
+    @stores_for_map = Store.where.not(lat: nil, lon: nil)
+                           .includes(:udon_shares)
+                           .preload(udon_shares: :store)
+
+    # アクティブなシェアをメモリ上でフィルタリング
     @stores_for_map_json = @stores_for_map.map do |store|
-      active_share = store.active_udon_share
+      active_share = store.udon_shares
+                          .select { |share| share.take_down_time > Time.current }
+                          .max_by(&:created_at)
 
       {
         id: store.id,

--- a/app/helpers/admin/stores_helper.rb
+++ b/app/helpers/admin/stores_helper.rb
@@ -1,0 +1,2 @@
+module Admin::StoresHelper
+end

--- a/app/helpers/admin/udon_shares_helper.rb
+++ b/app/helpers/admin/udon_shares_helper.rb
@@ -1,0 +1,2 @@
+module Admin::UdonSharesHelper
+end

--- a/app/javascript/controllers/maps_controller.js
+++ b/app/javascript/controllers/maps_controller.js
@@ -339,15 +339,24 @@ export default class MapsController extends Controller {
                 shareDetail.style.borderRadius = "4px";
 
                 const shareItem = document.createElement("div");
-                shareItem.innerHTML = `<strong>シェア中:</strong> ${shop.shareInfo.itemName}`;
+                const shareItemLabel = document.createElement("strong");
+                shareItemLabel.textContent = "シェア中: ";
+                shareItem.appendChild(shareItemLabel);
+                shareItem.appendChild(document.createTextNode(shop.shareInfo.itemName));
                 shareDetail.appendChild(shareItem);
 
                 const shareDesc = document.createElement("div");
-                shareDesc.innerHTML = `<strong>内容:</strong> ${shop.shareInfo.description}`;
+                const shareDescLabel = document.createElement("strong");
+                shareDescLabel.textContent = "内容: ";
+                shareDesc.appendChild(shareDescLabel);
+                shareDesc.appendChild(document.createTextNode(shop.shareInfo.description));
                 shareDetail.appendChild(shareDesc);
 
                 const shareTakeDown = document.createElement("div");
-                shareTakeDown.innerHTML = `<strong>取り下げ時間:</strong> ${shop.shareInfo.takeDownTime}`;
+                const shareTakeDownLabel = document.createElement("strong");
+                shareTakeDownLabel.textContent = "取り下げ時間: ";
+                shareTakeDown.appendChild(shareTakeDownLabel);
+                shareTakeDown.appendChild(document.createTextNode(shop.shareInfo.takeDownTime));
                 shareDetail.appendChild(shareTakeDown);
 
                 content.appendChild(shareDetail);

--- a/app/javascript/controllers/maps_controller.js
+++ b/app/javascript/controllers/maps_controller.js
@@ -226,6 +226,34 @@ export default class MapsController extends Controller {
         const markerIcon = document.createElement("div");
         markerIcon.className = "maps__marker";
 
+        // シェア情報がある場合、リサイクルマークと残り時間を追加
+        if (store.foodshare && store.shareInfo) {
+            const shareIndicator = document.createElement("div");
+            shareIndicator.className = "maps__marker-share";
+
+            // リサイクルマーク
+            const recycleIcon = document.createElement("span");
+            recycleIcon.className = "maps__marker-share-icon";
+            recycleIcon.textContent = "♻️";
+            shareIndicator.appendChild(recycleIcon);
+
+            // 残り時間を計算
+            const takeDownTime = new Date(store.shareInfo.takeDownTime);
+            const now = new Date();
+            const diffMs = takeDownTime - now;
+            const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+            const diffMinutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+
+            if (diffMs > 0) {
+                const timeText = document.createElement("span");
+                timeText.className = "maps__marker-share-time";
+                timeText.textContent = diffHours > 0 ? `${diffHours}h${diffMinutes}m` : `${diffMinutes}m`;
+                shareIndicator.appendChild(timeText);
+            }
+
+            markerIcon.appendChild(shareIndicator);
+        }
+
         // マーカーを作成
         const marker = new AdvancedMarkerElement({
             position,

--- a/app/javascript/controllers/maps_controller.js
+++ b/app/javascript/controllers/maps_controller.js
@@ -29,6 +29,14 @@ const mapOptions = {
 };
 
 /**
+ * @typedef {Object} ShareInfo
+ * @property {string} itemName
+ * @property {string} description
+ * @property {string} takeDownTime
+ * @property {string} photoUrl
+ */
+
+/**
  * @typedef {Object} StoreFeature
  * @property {number} id
  * @property {string} name
@@ -38,6 +46,7 @@ const mapOptions = {
  * @property {string | null | undefined} [address]
  * @property {boolean | null | undefined} [eco]
  * @property {boolean | null | undefined} [foodshare]
+ * @property {ShareInfo | null | undefined} [shareInfo]
  */
 
 // Connects to data-controller="maps"
@@ -319,6 +328,30 @@ export default class MapsController extends Controller {
             foodshareDesc.textContent = "フードシェア実施中";
             foodshareOptions.appendChild(foodshareDesc);
             content.appendChild(foodshareOptions);
+
+            // シェア詳細情報を追加
+            if (shop.shareInfo) {
+                const shareDetail = document.createElement("div");
+                shareDetail.className = "maps__info--share-detail";
+                shareDetail.style.marginTop = "8px";
+                shareDetail.style.padding = "8px";
+                shareDetail.style.backgroundColor = "#f0fdf4";
+                shareDetail.style.borderRadius = "4px";
+
+                const shareItem = document.createElement("div");
+                shareItem.innerHTML = `<strong>シェア中:</strong> ${shop.shareInfo.itemName}`;
+                shareDetail.appendChild(shareItem);
+
+                const shareDesc = document.createElement("div");
+                shareDesc.innerHTML = `<strong>内容:</strong> ${shop.shareInfo.description}`;
+                shareDetail.appendChild(shareDesc);
+
+                const shareTakeDown = document.createElement("div");
+                shareTakeDown.innerHTML = `<strong>取り下げ時間:</strong> ${shop.shareInfo.takeDownTime}`;
+                shareDetail.appendChild(shareTakeDown);
+
+                content.appendChild(shareDetail);
+            }
         }
 
         const address = document.createElement("div");

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -5,4 +5,16 @@ class Store < ApplicationRecord
   validates :lon, numericality: true, allow_nil: true
 
   has_many :received_reviews, class_name: "Review", foreign_key: "reviewee_id", dependent: :destroy
+
+  # 運営者
+  has_many :store_operators, dependent: :destroy
+  has_many :operators, through: :store_operators, source: :user
+
+  # うどんシェア
+  has_many :udon_shares, dependent: :destroy
+
+  # 現在アクティブなシェアを取得
+  def active_udon_share
+    udon_shares.active.order(created_at: :desc).first
+  end
 end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -12,9 +12,10 @@ class Store < ApplicationRecord
 
   # うどんシェア
   has_many :udon_shares, dependent: :destroy
+  has_one :active_udon_share, -> { active.order(created_at: :desc) }, class_name: "UdonShare"
 
   # 現在アクティブなシェアを取得
   def active_udon_share
-    udon_shares.active.order(created_at: :desc).first
+    super
   end
 end

--- a/app/models/store_operator.rb
+++ b/app/models/store_operator.rb
@@ -1,0 +1,6 @@
+class StoreOperator < ApplicationRecord
+  belongs_to :user
+  belongs_to :store
+
+  validates :user_id, uniqueness: { scope: :store_id }
+end

--- a/app/models/udon_share.rb
+++ b/app/models/udon_share.rb
@@ -3,7 +3,6 @@ class UdonShare < ApplicationRecord
 
   validates :item_name, presence: true
   validates :description, presence: true
-  validates :take_down_time, presence: true
 
   # 有効期限が切れていないシェアのみを取得
   scope :active, -> { where("take_down_time > ?", Time.current) }

--- a/app/models/udon_share.rb
+++ b/app/models/udon_share.rb
@@ -3,6 +3,7 @@ class UdonShare < ApplicationRecord
 
   validates :item_name, presence: true
   validates :description, presence: true
+  validates :take_down_time, presence: true
 
   # 有効期限が切れていないシェアのみを取得
   scope :active, -> { where("take_down_time > ?", Time.current) }

--- a/app/models/udon_share.rb
+++ b/app/models/udon_share.rb
@@ -1,0 +1,21 @@
+class UdonShare < ApplicationRecord
+  belongs_to :store
+
+  validates :item_name, presence: true
+  validates :description, presence: true
+  validates :take_down_time, presence: true
+  validates :photo_url, presence: true
+
+  # 有効期限が切れていないシェアのみを取得
+  scope :active, -> { where("take_down_time > ?", Time.current) }
+
+  # 有効期限が切れたか確認
+  def expired?
+    !active?
+  end
+
+  # 有効期限が切れていないか確認
+  def active?
+    take_down_time > Time.current
+  end
+end

--- a/app/models/udon_share.rb
+++ b/app/models/udon_share.rb
@@ -4,7 +4,6 @@ class UdonShare < ApplicationRecord
   validates :item_name, presence: true
   validates :description, presence: true
   validates :take_down_time, presence: true
-  validates :photo_url, presence: true
 
   # 有効期限が切れていないシェアのみを取得
   scope :active, -> { where("take_down_time > ?", Time.current) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,10 @@ class User < ApplicationRecord
   has_many :sessions, dependent: :destroy
   has_one :user_setting, dependent: :destroy
 
+  # 運営者として管理する店舗
+  has_many :store_operators, dependent: :destroy
+  has_many :operated_stores, through: :store_operators, source: :store
+
   validates :name, presence: true
   normalizes :email, with: ->(email) { email.strip.downcase }
   validates :email, presence: true, uniqueness: true

--- a/app/views/admin/stores/index.html.erb
+++ b/app/views/admin/stores/index.html.erb
@@ -1,0 +1,50 @@
+<div class="container mx-auto px-4 py-8">
+  <div class="flex justify-between items-center mb-6">
+    <h1 class="text-3xl font-bold">運営中の店舗</h1>
+    <%= link_to "店舗を追加する", select_admin_stores_path, class: "bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded" %>
+  </div>
+
+  <% if @operated_stores.any? %>
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <% @operated_stores.each do |store| %>
+        <div class="border rounded-lg p-6 shadow-lg bg-white">
+          <div class="flex justify-between items-start mb-4">
+            <div>
+              <h3 class="text-xl font-semibold mb-1"><%= store.name %></h3>
+              <p class="text-gray-600 text-sm"><%= store.address %></p>
+            </div>
+          </div>
+
+          <% if store.is_share %>
+            <% if active_share = store.active_udon_share %>
+              <div class="bg-green-100 border border-green-400 rounded p-3 mb-4">
+                <p class="text-sm font-semibold text-green-800 mb-1">
+                  🎁 シェア中: <%= active_share.item_name %>
+                </p>
+                <p class="text-xs text-green-700 mb-1"><%= active_share.description %></p>
+                <p class="text-xs text-green-600">取り下げ: <%= active_share.take_down_time.strftime('%m/%d %H:%M') %></p>
+                <div class="mt-2">
+                  <%= button_to "シェア削除", admin_udon_share_path(active_share), method: :delete, data: { confirm: "削除しますか？" }, class: "bg-red-500 hover:bg-red-700 text-white font-bold py-1 px-3 rounded text-xs" %>
+                </div>
+              </div>
+            <% end %>
+          <% else %>
+            <div class="bg-gray-100 border border-gray-300 rounded p-3 mb-4">
+              <p class="text-sm text-gray-600">現在シェアはありません</p>
+            </div>
+          <% end %>
+
+          <div class="flex gap-2 mt-4">
+            <%= link_to "シェアを追加", new_admin_store_udon_share_path(store), class: "flex-1 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded text-sm text-center" %>
+            <%= button_to "運営解除", remove_operator_admin_store_path(store), method: :delete, data: { confirm: "本当に運営を解除しますか？" }, class: "bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded text-sm" %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="bg-yellow-100 border border-yellow-400 rounded p-6 text-center">
+      <p class="text-lg mb-4">まだ運営している店舗がありません</p>
+      <%= link_to "店舗を追加する", select_admin_stores_path, class: "bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-6 rounded inline-block" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/stores/index.html.erb
+++ b/app/views/admin/stores/index.html.erb
@@ -1,56 +1,55 @@
-<div class="container mx-auto px-4 py-8">
-  <div class="flex justify-between items-center mb-6">
-    <h1 class="text-3xl font-bold">運営中の店舗</h1>
-    <%= link_to "店舗を追加する", select_admin_stores_path, class: "bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded" %>
+<div class="admin__container">
+  <div class="admin__header">
+    <h1 class="admin__title">運営中の店舗</h1>
+    <%= link_to "店舗を追加する", select_admin_stores_path, class: "admin__btn admin__btn--success" %>
   </div>
 
   <% if @operated_stores.any? %>
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+    <div class="admin__grid">
       <% @operated_stores.each do |store| %>
-        <div class="border rounded-lg p-6 shadow-lg bg-white">
-          <div class="flex justify-between items-start mb-4">
-            <div>
-              <h3 class="text-xl font-semibold mb-1"><%= store.name %></h3>
-              <p class="text-gray-600 text-sm"><%= store.address %></p>
+        <div class="admin__store-card">
+          <div class="admin__store-header">
+            <div class="admin__store-info">
+              <h3 class="admin__store-name"><%= store.name %></h3>
+              <p class="admin__store-address"><%= store.address %></p>
             </div>
           </div>
 
           <% if store.is_share %>
             <% if active_share = store.active_udon_share %>
-              <div class="bg-green-100 border border-green-400 rounded p-3 mb-4">
-                <p class="text-sm font-semibold text-green-800 mb-1">
-                  🎁 シェア中: <%= active_share.item_name %>
-                </p>
-                <p class="text-xs text-green-700 mb-1"><%= active_share.description %></p>
-                <p class="text-xs text-green-600">取り下げ: <%= active_share.take_down_time&.strftime('%m/%d %H:%M') || '未設定' %></p>
-                <div class="mt-2">
-                  <%= button_to "シェア削除", admin_udon_share_path(active_share), method: :delete, data: { confirm: "削除しますか？" }, class: "bg-red-500 hover:bg-red-700 text-white font-bold py-1 px-3 rounded text-xs" %>
+              <div class="admin__share-box">
+                <p class="admin__share-title">シェア中: <%= active_share.item_name %></p>
+                <p class="admin__share-description"><%= active_share.description %></p>
+                <p class="admin__share-time">取り下げ: <%= active_share.take_down_time&.strftime('%m/%d %H:%M') || '未設定' %></p>
+                <div class="admin__button-group" style="margin-top: 0.75rem;">
+                  <%= button_to "シェア削除", admin_udon_share_path(active_share), method: :delete, data: { confirm: "削除しますか？" }, class: "admin__btn admin__btn--danger admin__btn--small" %>
                 </div>
               </div>
             <% end %>
           <% else %>
-            <div class="bg-gray-100 border border-gray-300 rounded p-3 mb-4">
-              <p class="text-sm text-gray-600">現在シェアはありません</p>
+            <div class="admin__share-box admin__share-box--empty">
+              <p class="admin__share-empty">現在シェアはありません</p>
             </div>
           <% end %>
 
-          <div class="flex gap-2 mt-4">
+          <div class="admin__button-group">
             <% if store.active_udon_share %>
-              <button disabled class="flex-1 bg-gray-300 text-gray-500 font-bold py-2 px-4 rounded text-sm text-center cursor-not-allowed" title="既にアクティブなシェアがあります">
+              <button disabled class="admin__btn admin__btn--disabled admin__button-flex" title="既にアクティブなシェアがあります">
                 シェアを追加
               </button>
             <% else %>
-              <%= link_to "シェアを追加", new_admin_store_udon_share_path(store), class: "flex-1 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded text-sm text-center" %>
+              <%= link_to "シェアを追加", new_admin_store_udon_share_path(store), class: "admin__btn admin__btn--info admin__button-flex" %>
             <% end %>
-            <%= button_to "運営解除", remove_operator_admin_store_path(store), method: :delete, data: { confirm: "本当に運営を解除しますか？" }, class: "bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded text-sm" %>
+            <%= button_to "運営解除", remove_operator_admin_store_path(store), method: :delete, data: { confirm: "本当に運営を解除しますか？" }, class: "admin__btn admin__btn--secondary" %>
           </div>
         </div>
       <% end %>
     </div>
   <% else %>
-    <div class="bg-yellow-100 border border-yellow-400 rounded p-6 text-center">
-      <p class="text-lg mb-4">まだ運営している店舗がありません</p>
-      <%= link_to "店舗を追加する", select_admin_stores_path, class: "bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-6 rounded inline-block" %>
+    <div class="admin__empty-state">
+      <div class="admin__empty-state-icon">🏪</div>
+      <p class="admin__empty-state-text">まだ運営している店舗がありません</p>
+      <%= link_to "店舗を追加する", select_admin_stores_path, class: "admin__btn admin__btn--success" %>
     </div>
   <% end %>
 </div>

--- a/app/views/admin/stores/index.html.erb
+++ b/app/views/admin/stores/index.html.erb
@@ -22,7 +22,7 @@
                   🎁 シェア中: <%= active_share.item_name %>
                 </p>
                 <p class="text-xs text-green-700 mb-1"><%= active_share.description %></p>
-                <p class="text-xs text-green-600">取り下げ: <%= active_share.take_down_time.strftime('%m/%d %H:%M') %></p>
+                <p class="text-xs text-green-600">取り下げ: <%= active_share.take_down_time&.strftime('%m/%d %H:%M') || '未設定' %></p>
                 <div class="mt-2">
                   <%= button_to "シェア削除", admin_udon_share_path(active_share), method: :delete, data: { confirm: "削除しますか？" }, class: "bg-red-500 hover:bg-red-700 text-white font-bold py-1 px-3 rounded text-xs" %>
                 </div>
@@ -35,7 +35,13 @@
           <% end %>
 
           <div class="flex gap-2 mt-4">
-            <%= link_to "シェアを追加", new_admin_store_udon_share_path(store), class: "flex-1 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded text-sm text-center" %>
+            <% if store.active_udon_share %>
+              <button disabled class="flex-1 bg-gray-300 text-gray-500 font-bold py-2 px-4 rounded text-sm text-center cursor-not-allowed" title="既にアクティブなシェアがあります">
+                シェアを追加
+              </button>
+            <% else %>
+              <%= link_to "シェアを追加", new_admin_store_udon_share_path(store), class: "flex-1 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded text-sm text-center" %>
+            <% end %>
             <%= button_to "運営解除", remove_operator_admin_store_path(store), method: :delete, data: { confirm: "本当に運営を解除しますか？" }, class: "bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded text-sm" %>
           </div>
         </div>

--- a/app/views/admin/stores/index.html.erb
+++ b/app/views/admin/stores/index.html.erb
@@ -40,7 +40,14 @@
             <% else %>
               <%= link_to "シェアを追加", new_admin_store_udon_share_path(store), class: "admin__btn admin__btn--info admin__button-flex" %>
             <% end %>
-            <%= button_to "運営解除", remove_operator_admin_store_path(store), method: :delete, data: { confirm: "本当に運営を解除しますか？" }, class: "admin__btn admin__btn--secondary" %>
+
+            <% if store.active_udon_share %>
+              <button disabled class="admin__btn admin__btn--disabled" title="アクティブなシェアがあるため運営解除できません">
+                運営解除
+              </button>
+            <% else %>
+              <%= button_to "運営解除", remove_operator_admin_store_path(store), method: :delete, data: { confirm: "本当に運営を解除しますか？" }, class: "admin__btn admin__btn--secondary" %>
+            <% end %>
           </div>
         </div>
       <% end %>

--- a/app/views/admin/stores/index.html.erb
+++ b/app/views/admin/stores/index.html.erb
@@ -1,7 +1,7 @@
 <div class="admin__container">
   <div class="admin__header">
     <h1 class="admin__title">運営中の店舗</h1>
-    <%= link_to "店舗を追加する", select_admin_stores_path, class: "admin__btn admin__btn--success" %>
+    <%= link_to "追加", select_admin_stores_path, class: "admin__btn admin__btn--success" %>
   </div>
 
   <% if @operated_stores.any? %>
@@ -45,14 +45,14 @@
             <% end %>
 
             <% if store.active_udon_share %>
-              <button disabled class="admin__btn admin__btn--disabled admin__btn--small" title="アクティブなシェアがあるため運営解除できません">
+              <button disabled class="admin__btn admin__btn--disabled" title="アクティブなシェアがあるため運営解除できません">
                 運営解除
               </button>
             <% else %>
               <%= button_to "運営解除", remove_operator_admin_store_path(store),
                            method: :delete,
                            form: { data: { turbo_confirm: t('confirms.admin.stores.remove_operator', store_name: store.name) } },
-                           class: "admin__btn admin__btn--secondary admin__btn--small" %>
+                           class: "admin__btn admin__btn--secondary" %>
             <% end %>
           </div>
         </div>

--- a/app/views/admin/stores/index.html.erb
+++ b/app/views/admin/stores/index.html.erb
@@ -16,7 +16,8 @@
           </div>
 
           <% if store.is_share %>
-            <% if active_share = store.active_udon_share %>
+            <% active_share = store.active_udon_share %>
+            <% if active_share %>
               <div class="admin__share-box">
                 <p class="admin__share-title">シェア中: <%= active_share.item_name %></p>
                 <p class="admin__share-description"><%= active_share.description %></p>

--- a/app/views/admin/stores/index.html.erb
+++ b/app/views/admin/stores/index.html.erb
@@ -22,7 +22,10 @@
                 <p class="admin__share-description"><%= active_share.description %></p>
                 <p class="admin__share-time">取り下げ: <%= active_share.take_down_time&.strftime('%m/%d %H:%M') || '未設定' %></p>
                 <div class="admin__button-group" style="margin-top: 0.75rem;">
-                  <%= button_to "シェア削除", admin_udon_share_path(active_share), method: :delete, data: { confirm: "削除しますか？" }, class: "admin__btn admin__btn--danger admin__btn--small" %>
+                  <%= button_to "シェア削除", admin_udon_share_path(active_share),
+                               method: :delete,
+                               form: { data: { turbo_confirm: t('confirms.admin.udon_shares.destroy', item_name: active_share.item_name) } },
+                               class: "admin__btn admin__btn--danger admin__btn--small" %>
                 </div>
               </div>
             <% end %>
@@ -42,11 +45,14 @@
             <% end %>
 
             <% if store.active_udon_share %>
-              <button disabled class="admin__btn admin__btn--disabled" title="アクティブなシェアがあるため運営解除できません">
+              <button disabled class="admin__btn admin__btn--disabled admin__btn--small" title="アクティブなシェアがあるため運営解除できません">
                 運営解除
               </button>
             <% else %>
-              <%= button_to "運営解除", remove_operator_admin_store_path(store), method: :delete, data: { confirm: "本当に運営を解除しますか？" }, class: "admin__btn admin__btn--secondary" %>
+              <%= button_to "運営解除", remove_operator_admin_store_path(store),
+                           method: :delete,
+                           form: { data: { turbo_confirm: t('confirms.admin.stores.remove_operator', store_name: store.name) } },
+                           class: "admin__btn admin__btn--secondary admin__btn--small" %>
             <% end %>
           </div>
         </div>

--- a/app/views/admin/stores/select.html.erb
+++ b/app/views/admin/stores/select.html.erb
@@ -1,39 +1,37 @@
-<div class="container mx-auto px-4 py-8 max-w-6xl">
-  <div class="mb-6">
-    <%= link_to "← 運営中の店舗に戻る", admin_stores_path, class: "text-blue-500 hover:text-blue-700" %>
+<div class="admin__container">
+  <div style="margin-bottom: 1.5rem;">
+    <%= link_to "← 運営中の店舗に戻る", admin_stores_path, class: "admin__btn admin__btn--secondary" %>
   </div>
 
-  <h1 class="text-3xl font-bold mb-6">運営する店舗を選択</h1>
+  <h1 class="admin__title">運営する店舗を選択</h1>
 
-  <div class="bg-blue-100 border border-blue-400 rounded p-4 mb-6">
-    <p class="text-sm">
+  <div class="admin__form-header" style="margin-top: 1.5rem;">
+    <p style="margin: 0;">
       <strong>🏪 店舗一覧</strong><br>
-      運営したい店舗を選択してください。全<%= @stores.count %>件の店舗があります。
+      <span style="font-size: 0.9rem; opacity: 0.9;">運営したい店舗を選択してください。全<%= @stores.count %>件の店舗があります。</span>
     </p>
   </div>
 
-  <!-- 店舗一覧 -->
   <% if @stores.any? %>
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+    <div class="admin__store-list">
       <% @stores.each do |store| %>
-        <div class="border rounded-lg p-4 shadow <%= @operated_store_ids.include?(store.id) ? 'bg-green-50 border-green-300' : 'bg-white' %>">
-          <div class="mb-3">
-            <h3 class="text-lg font-semibold mb-1"><%= store.name %></h3>
-            <p class="text-sm text-gray-600 mb-2"><%= store.address %></p>
+        <div class="admin__store-item <%= 'admin__store-item--operated' if @operated_store_ids.include?(store.id) %>">
+          <div class="admin__store-item-info">
+            <h3 class="admin__store-item-name"><%= store.name %></h3>
+            <p class="admin__store-item-address">📍 <%= store.address %></p>
             <% if store.open_time.present? %>
-              <p class="text-xs text-gray-500">🕐 <%= store.open_time %></p>
+              <p class="admin__store-item-address" style="margin-top: 0.2rem;">🕐 <%= store.open_time %></p>
+            <% end %>
+            <% if @operated_store_ids.include?(store.id) %>
+              <p class="admin__store-item-status">運営中</p>
             <% end %>
           </div>
 
           <div>
-            <% if @operated_store_ids.include?(store.id) %>
-              <span class="inline-block bg-green-500 text-white text-xs px-3 py-1 rounded w-full text-center">
-                ✓ 運営中
-              </span>
-            <% else %>
+            <% unless @operated_store_ids.include?(store.id) %>
               <%= button_to "運営する", add_operator_admin_store_path(store),
                            method: :post,
-                           class: "w-full bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded text-sm",
+                           class: "admin__btn admin__btn--primary",
                            data: { confirm: "#{store.name}の運営者になりますか？" } %>
             <% end %>
           </div>
@@ -41,8 +39,9 @@
       <% end %>
     </div>
   <% else %>
-    <div class="bg-gray-100 border border-gray-300 rounded p-6 text-center">
-      <p class="text-gray-600">店舗がありません</p>
+    <div class="admin__empty-state">
+      <div class="admin__empty-state-icon">🏪</div>
+      <p class="admin__empty-state-text">店舗がありません</p>
     </div>
   <% end %>
 </div>

--- a/app/views/admin/stores/select.html.erb
+++ b/app/views/admin/stores/select.html.erb
@@ -32,7 +32,7 @@
               <%= button_to "運営する", add_operator_admin_store_path(store),
                            method: :post,
                            class: "admin__btn admin__btn--primary",
-                           data: { confirm: "#{store.name}の運営者になりますか？" } %>
+                           form: { data: { turbo_confirm: t('confirms.admin.stores.add_operator', store_name: store.name) } } %>
             <% end %>
           </div>
         </div>

--- a/app/views/admin/stores/select.html.erb
+++ b/app/views/admin/stores/select.html.erb
@@ -1,0 +1,48 @@
+<div class="container mx-auto px-4 py-8 max-w-6xl">
+  <div class="mb-6">
+    <%= link_to "← 運営中の店舗に戻る", admin_stores_path, class: "text-blue-500 hover:text-blue-700" %>
+  </div>
+
+  <h1 class="text-3xl font-bold mb-6">運営する店舗を選択</h1>
+
+  <div class="bg-blue-100 border border-blue-400 rounded p-4 mb-6">
+    <p class="text-sm">
+      <strong>🏪 店舗一覧</strong><br>
+      運営したい店舗を選択してください。全<%= @stores.count %>件の店舗があります。
+    </p>
+  </div>
+
+  <!-- 店舗一覧 -->
+  <% if @stores.any? %>
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <% @stores.each do |store| %>
+        <div class="border rounded-lg p-4 shadow <%= @operated_store_ids.include?(store.id) ? 'bg-green-50 border-green-300' : 'bg-white' %>">
+          <div class="mb-3">
+            <h3 class="text-lg font-semibold mb-1"><%= store.name %></h3>
+            <p class="text-sm text-gray-600 mb-2"><%= store.address %></p>
+            <% if store.open_time.present? %>
+              <p class="text-xs text-gray-500">🕐 <%= store.open_time %></p>
+            <% end %>
+          </div>
+
+          <div>
+            <% if @operated_store_ids.include?(store.id) %>
+              <span class="inline-block bg-green-500 text-white text-xs px-3 py-1 rounded w-full text-center">
+                ✓ 運営中
+              </span>
+            <% else %>
+              <%= button_to "運営する", add_operator_admin_store_path(store),
+                           method: :post,
+                           class: "w-full bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded text-sm",
+                           data: { confirm: "#{store.name}の運営者になりますか？" } %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="bg-gray-100 border border-gray-300 rounded p-6 text-center">
+      <p class="text-gray-600">店舗がありません</p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/udon_shares/new.html.erb
+++ b/app/views/admin/udon_shares/new.html.erb
@@ -1,47 +1,47 @@
-<div class="container mx-auto px-4 py-8 max-w-2xl">
-  <h1 class="text-3xl font-bold mb-6">うどんシェアを設定</h1>
+<div class="admin__form">
+  <h1 class="admin__title" style="text-align: center; margin-bottom: 1.5rem;">うどんシェアを設定</h1>
 
-  <div class="bg-blue-100 border border-blue-400 rounded p-4 mb-6">
-    <p class="font-semibold">店舗: <%= @store.name %></p>
-    <p class="text-sm text-gray-700"><%= @store.address %></p>
+  <div class="admin__form-header">
+    <p class="admin__form-store-name"><%= @store.name %></p>
+    <p class="admin__form-store-address">📍 <%= @store.address %></p>
   </div>
 
-  <%= form_with model: @udon_share, url: admin_store_udon_shares_path(@store), class: "space-y-4" do |f| %>
+  <%= form_with model: @udon_share, url: admin_store_udon_shares_path(@store) do |f| %>
     <% if @udon_share.errors.any? %>
-      <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
-        <h2 class="font-bold mb-2"><%= pluralize(@udon_share.errors.count, "個のエラー") %>があります:</h2>
-        <ul class="list-disc list-inside">
+      <div class="admin__errors">
+        <h2 class="admin__errors-title"><%= pluralize(@udon_share.errors.count, "個のエラー") %>があります</h2>
+        <ul class="admin__errors-list">
           <% @udon_share.errors.full_messages.each do |message| %>
-            <li><%= message %></li>
+            <li class="admin__errors-item"><%= message %></li>
           <% end %>
         </ul>
       </div>
     <% end %>
 
-    <div>
-      <%= f.label :item_name, "シェアするもの", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.text_field :item_name, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500", placeholder: "例: かけうどん" %>
+    <div class="admin__form-group">
+      <%= f.label :item_name, "シェアするもの", class: "admin__form-label admin__form-label--required" %>
+      <%= f.text_field :item_name, class: "admin__form-input", placeholder: "例: かけうどん" %>
     </div>
 
-    <div>
-      <%= f.label :description, "具体的な内容物", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.text_area :description, rows: 4, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500", placeholder: "例: かけうどん(大)、天ぷら2個、おにぎり1個" %>
+    <div class="admin__form-group">
+      <%= f.label :description, "具体的な内容物", class: "admin__form-label admin__form-label--required" %>
+      <%= f.text_area :description, rows: 4, class: "admin__form-textarea", placeholder: "例: かけうどん(大)、天ぷら2個、おにぎり1個" %>
     </div>
 
-    <div>
-      <%= f.label :take_down_time, "取り下げ時間", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.datetime_local_field :take_down_time, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
+    <div class="admin__form-group">
+      <%= f.label :take_down_time, "取り下げ時間", class: "admin__form-label admin__form-label--required" %>
+      <%= f.datetime_local_field :take_down_time, class: "admin__form-input" %>
     </div>
 
-    <div>
-      <%= f.label :photo_url, "写真URL（任意）", class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.text_field :photo_url, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500", placeholder: "https://example.com/photo.jpg" %>
-      <p class="text-xs text-gray-500 mt-1">※任意項目です。画像URLを直接入力してください</p>
+    <div class="admin__form-group">
+      <%= f.label :photo_url, "写真URL", class: "admin__form-label admin__form-label--optional" %>
+      <%= f.text_field :photo_url, class: "admin__form-input", placeholder: "https://example.com/photo.jpg" %>
+      <span class="admin__form-help">※任意項目です。画像URLを直接入力してください</span>
     </div>
 
-    <div class="flex gap-4">
-      <%= f.submit "設定する", class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded cursor-pointer" %>
-      <%= link_to "キャンセル", admin_stores_path, class: "bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded" %>
+    <div class="admin__form-actions">
+      <%= f.submit "設定する", class: "admin__btn admin__btn--primary admin__button-flex" %>
+      <%= link_to "キャンセル", admin_stores_path, class: "admin__btn admin__btn--secondary" %>
     </div>
   <% end %>
 </div>

--- a/app/views/admin/udon_shares/new.html.erb
+++ b/app/views/admin/udon_shares/new.html.erb
@@ -1,0 +1,47 @@
+<div class="container mx-auto px-4 py-8 max-w-2xl">
+  <h1 class="text-3xl font-bold mb-6">うどんシェアを設定</h1>
+
+  <div class="bg-blue-100 border border-blue-400 rounded p-4 mb-6">
+    <p class="font-semibold">店舗: <%= @store.name %></p>
+    <p class="text-sm text-gray-700"><%= @store.address %></p>
+  </div>
+
+  <%= form_with model: @udon_share, url: admin_store_udon_shares_path(@store), class: "space-y-4" do |f| %>
+    <% if @udon_share.errors.any? %>
+      <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded">
+        <h2 class="font-bold mb-2"><%= pluralize(@udon_share.errors.count, "個のエラー") %>があります:</h2>
+        <ul class="list-disc list-inside">
+          <% @udon_share.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <div>
+      <%= f.label :item_name, "シェアするもの", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.text_field :item_name, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500", placeholder: "例: かけうどん" %>
+    </div>
+
+    <div>
+      <%= f.label :description, "具体的な内容物", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.text_area :description, rows: 4, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500", placeholder: "例: かけうどん(大)、天ぷら2個、おにぎり1個" %>
+    </div>
+
+    <div>
+      <%= f.label :take_down_time, "取り下げ時間", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.datetime_local_field :take_down_time, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500" %>
+    </div>
+
+    <div>
+      <%= f.label :photo_url, "写真URL", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.text_field :photo_url, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500", placeholder: "https://example.com/photo.jpg" %>
+      <p class="text-xs text-gray-500 mt-1">※今回は画像URLを直接入力してください</p>
+    </div>
+
+    <div class="flex gap-4">
+      <%= f.submit "設定する", class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded cursor-pointer" %>
+      <%= link_to "キャンセル", admin_stores_path, class: "bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/udon_shares/new.html.erb
+++ b/app/views/admin/udon_shares/new.html.erb
@@ -9,7 +9,8 @@
   <%= form_with model: @udon_share, url: admin_store_udon_shares_path(@store) do |f| %>
     <% if @udon_share.errors.any? %>
       <div class="admin__errors">
-        <h2 class="admin__errors-title"><%= pluralize(@udon_share.errors.count, "個のエラー") %>があります</h2>
+        <h2 class="admin__errors-title"><%= @udon_share.errors.count %>個のエラーがあります</h2>
+
         <ul class="admin__errors-list">
           <% @udon_share.errors.full_messages.each do |message| %>
             <li class="admin__errors-item"><%= message %></li>

--- a/app/views/admin/udon_shares/new.html.erb
+++ b/app/views/admin/udon_shares/new.html.erb
@@ -34,9 +34,9 @@
     </div>
 
     <div>
-      <%= f.label :photo_url, "写真URL", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.label :photo_url, "写真URL（任意）", class: "block text-sm font-medium text-gray-700 mb-1" %>
       <%= f.text_field :photo_url, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500", placeholder: "https://example.com/photo.jpg" %>
-      <p class="text-xs text-gray-500 mt-1">※今回は画像URLを直接入力してください</p>
+      <p class="text-xs text-gray-500 mt-1">※任意項目です。画像URLを直接入力してください</p>
     </div>
 
     <div class="flex gap-4">

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <title><%= content_for(:title) || "管理画面 - UNDO" %></title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= yield :head %>
+    <link rel="icon" href="/icon.png" type="image/png">
+    <link rel="icon" href="/icon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="/icon.png">
+    <%= stylesheet_link_tag "main", "data-turbo-track": "reload" %>
+    <% if Rails.env.production? %>
+      <%= stylesheet_link_tag "admin", "data-turbo-track": "reload" %>
+    <% else %>
+      <link rel="stylesheet" href="/assets/builds/admin.css" data-turbo-track="reload">
+    <% end %>
+    <%= javascript_importmap_tags %>
+  </head>
+
+  <body data-controller="user-menu" data-action="click@window->user-menu#close">
+    <%= render "shared/header" %>
+    <main>
+      <%= render "shared/flash" %>
+      <%= yield %>
+    </main>
+    <%= render "shared/footer" %>
+  </body>
+</html>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -12,11 +12,7 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
     <%= stylesheet_link_tag "main", "data-turbo-track": "reload" %>
-    <% if Rails.env.production? %>
-      <%= stylesheet_link_tag "admin", "data-turbo-track": "reload" %>
-    <% else %>
-      <link rel="stylesheet" href="/assets/builds/admin.css" data-turbo-track="reload">
-    <% end %>
+    <%= stylesheet_link_tag "admin", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 

--- a/app/views/shared/_header.erb
+++ b/app/views/shared/_header.erb
@@ -1,5 +1,5 @@
 <header class="header__container">
-  <%= image_tag "logo.png", class: "header__logo", alt: "UNDO Logo" %>
+  <%= link_to image_tag("logo.png", class: "header__logo", alt: "UNDO Logo"), root_path %>
   <div class="header__right">
     <% if authenticated? %>
       <div class="user-menu" data-user-type="<%= Current.session.user.is_company? ? 'company' : 'personal' %>">

--- a/app/views/shared/_header.erb
+++ b/app/views/shared/_header.erb
@@ -35,6 +35,14 @@
             </div>
           </div>
           <ul class="user-menu__list">
+            <% if Current.session.user.is_company? %>
+              <li class="user-menu__item">
+                <%= link_to admin_stores_path, class: "user-menu__link" do %>
+                  <span class="user-menu__icon">🏪</span>
+                  <span>店舗管理</span>
+                <% end %>
+              </li>
+            <% end %>
             <li class="user-menu__item">
               <%= link_to "#", class: "user-menu__link" do %>
                 <span class="user-menu__icon">📝</span>

--- a/app/views/shared/_header.erb
+++ b/app/views/shared/_header.erb
@@ -1,5 +1,5 @@
 <header class="header__container">
-  <%= link_to image_tag("logo.png", class: "header__logo", alt: "UNDO Logo"), root_path %>
+  <%= link_to image_tag("logo.png", alt: "UNDO Logo"), root_path, class: "header__logo" %>
   <div class="header__right">
     <% if authenticated? %>
       <div class="user-menu" data-user-type="<%= Current.session.user.is_company? ? 'company' : 'personal' %>">

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,4 +50,9 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
+
+  # Serve assets from app/assets/builds in test environment
+  config.assets.compile = false
+  config.assets.prefix = "/assets"
+  config.public_file_server.enabled = true
 end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,3 +5,8 @@ Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
+
+# Precompile additional assets.
+# application.js, application.css, and all non-JS/CSS in the app/assets
+# folder are already added.
+Rails.application.config.assets.precompile += %w[ admin.css ]

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,3 +1,4 @@
 Rails.application.config.dartsass.builds = {
-  "main.scss"  => "main.css"
+  "main.scss"  => "main.css",
+  "admin.scss" => "admin.css"
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,27 @@ en:
             signed_in: "Signed in successfully."
             signed_out: "Signed out successfully."
             invalid_credentials: "Email or password is incorrect."
+        admin:
+            stores:
+                operator_added: "You have become an operator of %{store_name}."
+                operator_add_failed: "Failed to add operator."
+                already_operator: "You are already an operator of this store."
+                operator_removed: "You have left as an operator of %{store_name}."
+                operator_remove_failed: "Failed to remove operator."
+                not_operator: "You are not an operator of this store."
+                has_active_share: "Cannot leave as operator because there is an active share."
+                not_found: "Store not found."
+            udon_shares:
+                created: "Udon share has been set up."
+                create_failed: "Failed to set up udon share."
+                destroyed: "Udon share has been deleted."
+                destroy_failed: "Failed to delete udon share."
+                not_operator: "You are not an operator of this store."
+                unauthorized: "You do not have permission."
+                already_exists: "An active share already exists for this store."
+                not_found: "The specified data could not be found."
+            common:
+                login_required: "Login is required."
         errors:
             generic: "An error has occurred."
             not_found: "The specified resource could not be found."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,6 +70,14 @@ en:
             not_found: "The specified resource could not be found."
             unauthorized: "You do not have permission to perform this action."
 
+    confirms:
+        admin:
+            stores:
+                add_operator: 'Register as an operator of "%{store_name}". Are you sure?'
+                remove_operator: 'Remove yourself as an operator of "%{store_name}". Are you sure?'
+            udon_shares:
+                destroy: 'Delete the share "%{item_name}"?'
+
     activerecord:
         models:
             user: "User"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -40,6 +40,14 @@ ja:
             not_found: "指定されたリソースが見つかりません。"
             unauthorized: "この操作を実行する権限がありません。"
 
+    confirms:
+        admin:
+            stores:
+                add_operator: "「%{store_name}」の運営者として登録します。よろしいですか？"
+                remove_operator: "「%{store_name}」の運営を解除します。本当によろしいですか？"
+            udon_shares:
+                destroy: "「%{item_name}」のシェアを削除しますか？"
+
     activerecord:
         models:
             user: "ユーザー"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -14,6 +14,27 @@ ja:
             signed_in: "ログインしました。"
             signed_out: "ログアウトしました。"
             invalid_credentials: "メールアドレスまたはパスワードが正しくありません。"
+        admin:
+            stores:
+                operator_added: "%{store_name}の運営者になりました。"
+                operator_add_failed: "運営者の追加に失敗しました。"
+                already_operator: "既にこの店舗の運営者です。"
+                operator_removed: "%{store_name}の運営者から外れました。"
+                operator_remove_failed: "運営者の削除に失敗しました。"
+                not_operator: "この店舗の運営者ではありません。"
+                has_active_share: "アクティブなシェアがあるため、運営者から外れることができません。"
+                not_found: "店舗が見つかりませんでした。"
+            udon_shares:
+                created: "うどんシェアを設定しました。"
+                create_failed: "うどんシェアの設定に失敗しました。"
+                destroyed: "うどんシェアを削除しました。"
+                destroy_failed: "うどんシェアの削除に失敗しました。"
+                not_operator: "この店舗の運営者ではありません。"
+                unauthorized: "権限がありません。"
+                already_exists: "この店舗には既にアクティブなシェアが存在します。"
+                not_found: "指定されたデータが見つかりませんでした。"
+            common:
+                login_required: "ログインが必要です。"
         errors:
             generic: "エラーが発生しました。"
             not_found: "指定されたリソースが見つかりません。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,21 @@
 Rails.application.routes.draw do
+  namespace :admin do
+    resources :stores, only: [ :index ] do
+      collection do
+        get :select
+      end
+
+      member do
+        post :add_operator
+        delete :remove_operator
+      end
+
+      resources :udon_shares, only: [ :new, :create ]
+    end
+
+    resources :udon_shares, only: [ :destroy ]
+  end
+
   resources :passwords, param: :token
   resources :measurements do
     get :status, on: :member

--- a/db/migrate/20251010025841_add_is_eco_and_is_share_to_stores.rb
+++ b/db/migrate/20251010025841_add_is_eco_and_is_share_to_stores.rb
@@ -1,0 +1,6 @@
+class AddIsEcoAndIsShareToStores < ActiveRecord::Migration[8.0]
+  def change
+    add_column :stores, :is_eco, :boolean, default: false, null: false
+    add_column :stores, :is_share, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20251010025934_create_store_operators.rb
+++ b/db/migrate/20251010025934_create_store_operators.rb
@@ -1,0 +1,12 @@
+class CreateStoreOperators < ActiveRecord::Migration[8.0]
+  def change
+    create_table :store_operators do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :store, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :store_operators, [:user_id, :store_id], unique: true
+  end
+end

--- a/db/migrate/20251010030050_create_udon_shares.rb
+++ b/db/migrate/20251010030050_create_udon_shares.rb
@@ -1,0 +1,13 @@
+class CreateUdonShares < ActiveRecord::Migration[8.0]
+  def change
+    create_table :udon_shares do |t|
+      t.references :store, null: false, foreign_key: true
+      t.string :item_name
+      t.text :description
+      t.datetime :take_down_time
+      t.string :photo_url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251010030050_create_udon_shares.rb
+++ b/db/migrate/20251010030050_create_udon_shares.rb
@@ -2,9 +2,9 @@ class CreateUdonShares < ActiveRecord::Migration[8.0]
   def change
     create_table :udon_shares do |t|
       t.references :store, null: false, foreign_key: true
-      t.string :item_name
-      t.text :description
-      t.datetime :take_down_time
+      t.string :item_name, null: false
+      t.text :description, null: false
+      t.datetime :take_down_time, null: false
       t.string :photo_url
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_09_084435) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_10_030050) do
   create_table "measurements", force: :cascade do |t|
     t.float "turbidity"
     t.float "predicted_bod"
@@ -47,6 +47,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_09_084435) do
     t.index ["user_id"], name: "index_sessions_on_user_id"
   end
 
+  create_table "store_operators", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "store_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["store_id"], name: "index_store_operators_on_store_id"
+    t.index ["user_id", "store_id"], name: "index_store_operators_on_user_id_and_store_id", unique: true
+    t.index ["user_id"], name: "index_store_operators_on_user_id"
+  end
+
   create_table "stores", force: :cascade do |t|
     t.string "name", null: false
     t.float "lat"
@@ -55,7 +65,20 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_09_084435) do
     t.string "address", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "is_eco", default: false, null: false
+    t.boolean "is_share", default: false, null: false
     t.index ["name", "address"], name: "index_stores_on_name_and_address", unique: true
+  end
+
+  create_table "udon_shares", force: :cascade do |t|
+    t.integer "store_id", null: false
+    t.string "item_name"
+    t.text "description"
+    t.datetime "take_down_time"
+    t.string "photo_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["store_id"], name: "index_udon_shares_on_store_id"
   end
 
   create_table "user_settings", force: :cascade do |t|
@@ -80,5 +103,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_09_084435) do
   add_foreign_key "reviews", "stores", column: "reviewee_id"
   add_foreign_key "reviews", "users", column: "reviewer_id"
   add_foreign_key "sessions", "users"
+  add_foreign_key "store_operators", "stores"
+  add_foreign_key "store_operators", "users"
+  add_foreign_key "udon_shares", "stores"
   add_foreign_key "user_settings", "users"
 end

--- a/test/controllers/admin/stores_controller_test.rb
+++ b/test/controllers/admin/stores_controller_test.rb
@@ -32,12 +32,24 @@ class Admin::StoresControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should remove operator" do
-    store = stores(:one)
+    # stores(:two)にはアクティブなシェアがないので削除可能
+    store = stores(:two)
     assert_difference("StoreOperator.count", -1) do
       delete remove_operator_admin_store_url(store)
     end
     assert_redirected_to admin_stores_path
     assert_equal "#{store.name}の運営者から外れました。", flash[:notice]
+  end
+
+  test "should not remove operator when store has active share" do
+    # stores(:one)にはアクティブなシェア(udon_shares(:one))がある
+    store = stores(:one)
+
+    assert_no_difference("StoreOperator.count") do
+      delete remove_operator_admin_store_url(store)
+    end
+    assert_redirected_to admin_stores_path
+    assert_equal "アクティブなシェアがあるため、運営者から外れることができません。", flash[:alert]
   end
 
   test "should redirect to signin when not logged in" do

--- a/test/controllers/admin/stores_controller_test.rb
+++ b/test/controllers/admin/stores_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class Admin::StoresControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one) # fixtures/users.yml に管理者ユーザーがいる場合
+    sign_in @user       # Devise を使っている場合
+  end
+
+  test "should get index" do
+    get admin_stores_url
+    assert_response :success
+  end
+end

--- a/test/controllers/admin/stores_controller_test.rb
+++ b/test/controllers/admin/stores_controller_test.rb
@@ -52,6 +52,39 @@ class Admin::StoresControllerTest < ActionDispatch::IntegrationTest
     assert_equal "アクティブなシェアがあるため、運営者から外れることができません。", flash[:alert]
   end
 
+  test "should not add operator when already operator" do
+    store = stores(:one) # bobは既にこの店舗の運営者
+
+    assert_no_difference("StoreOperator.count") do
+      post add_operator_admin_store_url(store)
+    end
+    assert_redirected_to admin_stores_path
+    assert_equal "既にこの店舗の運営者です。", flash[:alert]
+  end
+
+  test "should show error when store not found on add_operator" do
+    post add_operator_admin_store_url(id: 99999)
+    assert_redirected_to admin_stores_path
+    assert_equal "店舗が見つかりませんでした。", flash[:alert]
+  end
+
+  test "should show error when store not found on remove_operator" do
+    delete remove_operator_admin_store_url(id: 99999)
+    assert_redirected_to admin_stores_path
+    assert_equal "店舗が見つかりませんでした。", flash[:alert]
+  end
+
+  test "should not remove operator when not an operator" do
+    # 別のユーザーの店舗を作成
+    store = Store.create!(name: "Another Store", address: "Another Address")
+
+    assert_no_difference("StoreOperator.count") do
+      delete remove_operator_admin_store_url(store)
+    end
+    assert_redirected_to admin_stores_path
+    assert_equal "この店舗の運営者ではありません。", flash[:alert]
+  end
+
   test "should redirect to signin when not logged in" do
     sign_out
 

--- a/test/controllers/admin/stores_controller_test.rb
+++ b/test/controllers/admin/stores_controller_test.rb
@@ -2,12 +2,48 @@ require "test_helper"
 
 class Admin::StoresControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @user = users(:one) # fixtures/users.yml に管理者ユーザーがいる場合
-    sign_in @user       # Devise を使っている場合
+    @user = users(:bob) # 企業アカウント
+
+    # サインイン
+    sign_in_as(@user, password: "passwordbob")
   end
 
   test "should get index" do
     get admin_stores_url
     assert_response :success
+    assert_select "h1", "運営中の店舗"
+  end
+
+  test "should get select" do
+    get select_admin_stores_url
+    assert_response :success
+    assert_select "h1", "運営する店舗を選択"
+  end
+
+  test "should add operator" do
+    # carolという別のユーザーの店舗を作成
+    store = Store.create!(name: "Test Store", address: "Test Address")
+
+    assert_difference("StoreOperator.count") do
+      post add_operator_admin_store_url(store)
+    end
+    assert_redirected_to admin_stores_path
+    assert_equal "#{store.name}の運営者になりました。", flash[:notice]
+  end
+
+  test "should remove operator" do
+    store = stores(:one)
+    assert_difference("StoreOperator.count", -1) do
+      delete remove_operator_admin_store_url(store)
+    end
+    assert_redirected_to admin_stores_path
+    assert_equal "#{store.name}の運営者から外れました。", flash[:notice]
+  end
+
+  test "should redirect to signin when not logged in" do
+    sign_out
+
+    get admin_stores_url
+    assert_redirected_to signin_path
   end
 end

--- a/test/controllers/admin/udon_shares_controller_test.rb
+++ b/test/controllers/admin/udon_shares_controller_test.rb
@@ -11,12 +11,27 @@ class Admin::UdonSharesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get new" do
+    # 既存のアクティブなシェアを削除
+    @store.udon_shares.destroy_all
+
     get new_admin_store_udon_share_url(@store)
     assert_response :success
     assert_select "h1", "うどんシェアを設定"
   end
 
+  test "should not get new when active share exists" do
+    # すでにアクティブなシェアがある（fixtureのone）
+    @store.update(is_share: true)
+
+    get new_admin_store_udon_share_url(@store)
+    assert_redirected_to admin_stores_path
+    assert_equal "この店舗には既にアクティブなシェアが存在します。", flash[:alert]
+  end
+
   test "should create udon_share" do
+    # 既存のアクティブなシェアを削除
+    @store.udon_shares.destroy_all
+
     assert_difference("UdonShare.count") do
       post admin_store_udon_shares_url(@store), params: {
         udon_share: {
@@ -39,6 +54,9 @@ class Admin::UdonSharesControllerTest < ActionDispatch::IntegrationTest
   test "should destroy udon_share" do
     # まずis_shareをtrueにする
     @store.update(is_share: true)
+
+    # 他のアクティブなシェアを削除（oneだけを残す）
+    @store.udon_shares.where.not(id: @udon_share.id).destroy_all
 
     assert_difference("UdonShare.count", -1) do
       delete admin_udon_share_url(@udon_share)

--- a/test/controllers/admin/udon_shares_controller_test.rb
+++ b/test/controllers/admin/udon_shares_controller_test.rb
@@ -2,25 +2,77 @@ require "test_helper"
 
 class Admin::UdonSharesControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @store_operator = users(:store_operator) # 適切なfixture名に変更してください
-    @store = stores(:one) # 適切なfixture名に変更してください
-    @udon_share = udon_shares(:one) # 適切なfixture名に変更してください
-    sign_in @store_operator # deviseを利用している場合
+    @user = users(:bob) # 企業アカウント
+    @store = stores(:one)
+    @udon_share = udon_shares(:one)
+
+    # サインイン
+    sign_in_as(@user, password: "passwordbob")
   end
 
   test "should get new" do
-    get admin_udon_shares_new_url(store_id: @store.id)
+    get new_admin_store_udon_share_url(@store)
     assert_response :success
+    assert_select "h1", "うどんシェアを設定"
   end
 
-  test "should get create" do
-    post admin_udon_shares_create_url(store_id: @store.id), params: { udon_share: { some_attribute: "value" } }
-    assert_response :success
+  test "should create udon_share" do
+    assert_difference("UdonShare.count") do
+      post admin_store_udon_shares_url(@store), params: {
+        udon_share: {
+          item_name: "かけうどん",
+          description: "大盛り、天ぷら付き",
+          take_down_time: 2.hours.from_now,
+          photo_url: "https://example.com/photo.jpg"
+        }
+      }
+    end
+
+    # is_shareフラグが立っているか確認
+    @store.reload
+    assert @store.is_share
+
+    assert_redirected_to admin_stores_path
+    assert_equal "うどんシェアを設定しました。", flash[:notice]
   end
 
-  test "should get destroy" do
-    delete admin_udon_share_url(@udon_share, store_id: @store.id)
-    assert_response :success
+  test "should destroy udon_share" do
+    # まずis_shareをtrueにする
+    @store.update(is_share: true)
+
+    assert_difference("UdonShare.count", -1) do
+      delete admin_udon_share_url(@udon_share)
+    end
+
+    # アクティブなシェアがなくなったのでis_shareフラグが下がっているか確認
+    @store.reload
+    assert_not @store.is_share
+
+    assert_redirected_to admin_stores_path
+    assert_equal "うどんシェアを削除しました。", flash[:notice]
   end
-end
+
+  test "should not allow non-operator to create share" do
+    # 別の店舗（bobが運営していない）
+    other_store = Store.create!(name: "Other Store", address: "Other Address")
+
+    post admin_store_udon_shares_url(other_store), params: {
+      udon_share: {
+        item_name: "かけうどん",
+        description: "大盛り",
+        take_down_time: 2.hours.from_now,
+        photo_url: "https://example.com/photo.jpg"
+      }
+    }
+
+    assert_redirected_to admin_stores_path
+    assert_equal "この店舗の運営者ではありません。", flash[:alert]
+  end
+
+  test "should redirect to signin when not logged in" do
+    sign_out
+
+    get new_admin_store_udon_share_url(@store)
+    assert_redirected_to signin_path
+  end
 end

--- a/test/controllers/admin/udon_shares_controller_test.rb
+++ b/test/controllers/admin/udon_shares_controller_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class Admin::UdonSharesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @store_operator = users(:store_operator) # 適切なfixture名に変更してください
+    @store = stores(:one) # 適切なfixture名に変更してください
+    @udon_share = udon_shares(:one) # 適切なfixture名に変更してください
+    sign_in @store_operator # deviseを利用している場合
+  end
+
+  test "should get new" do
+    get admin_udon_shares_new_url(store_id: @store.id)
+    assert_response :success
+  end
+
+  test "should get create" do
+    post admin_udon_shares_create_url(store_id: @store.id), params: { udon_share: { some_attribute: "value" } }
+    assert_response :success
+  end
+
+  test "should get destroy" do
+    delete admin_udon_share_url(@udon_share, store_id: @store.id)
+    assert_response :success
+  end
+end
+end

--- a/test/controllers/admin/udon_shares_controller_test.rb
+++ b/test/controllers/admin/udon_shares_controller_test.rb
@@ -87,6 +87,36 @@ class Admin::UdonSharesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "この店舗の運営者ではありません。", flash[:alert]
   end
 
+  test "should not create udon_share with invalid params" do
+    # 既存のアクティブなシェアを削除
+    @store.udon_shares.destroy_all
+
+    assert_no_difference("UdonShare.count") do
+      post admin_store_udon_shares_url(@store), params: {
+        udon_share: {
+          item_name: "", # 空の商品名（無効）
+          description: "大盛り、天ぷら付き",
+          take_down_time: 2.hours.from_now
+        }
+      }
+    end
+
+    assert_response :unprocessable_entity
+    assert_equal "うどんシェアの設定に失敗しました。", flash[:alert]
+  end
+
+  test "should show error when udon_share not found on destroy" do
+    delete admin_udon_share_url(id: 99999)
+    assert_redirected_to admin_stores_path
+    assert_equal "指定されたデータが見つかりませんでした。", flash[:alert]
+  end
+
+  test "should show error when store not found on new" do
+    get new_admin_store_udon_share_url(store_id: 99999)
+    assert_redirected_to admin_stores_path
+    assert_equal "指定されたデータが見つかりませんでした。", flash[:alert]
+  end
+
   test "should redirect to signin when not logged in" do
     sign_out
 

--- a/test/fixtures/store_operators.yml
+++ b/test/fixtures/store_operators.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  store: one
+
+two:
+  user: two
+  store: two

--- a/test/fixtures/store_operators.yml
+++ b/test/fixtures/store_operators.yml
@@ -1,9 +1,9 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  user: one
-  store: one
+    user: bob
+    store: one
 
 two:
-  user: two
-  store: two
+    user: bob
+    store: two

--- a/test/fixtures/udon_shares.yml
+++ b/test/fixtures/udon_shares.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  store: one
+  item_name: MyString
+  description: MyText
+  take_down_time: 2025-10-10 12:00:51
+  photo_url: MyString
+
+two:
+  store: two
+  item_name: MyString
+  description: MyText
+  take_down_time: 2025-10-10 12:00:51
+  photo_url: MyString

--- a/test/fixtures/udon_shares.yml
+++ b/test/fixtures/udon_shares.yml
@@ -11,7 +11,7 @@ two:
     store: two
     item_name: ぶっかけうどん
     description: ぶっかけうどん、おにぎり1個
-    take_down_time: <%= 1.hour.from_now %>
+    take_down_time: <%= 1.hour.ago %>
     photo_url: https://example.com/photo2.jpg
 
 without_photo:

--- a/test/fixtures/udon_shares.yml
+++ b/test/fixtures/udon_shares.yml
@@ -1,15 +1,22 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  store: one
-  item_name: MyString
-  description: MyText
-  take_down_time: 2025-10-10 12:00:51
-  photo_url: MyString
+    store: one
+    item_name: かけうどん
+    description: かけうどん大盛り、天ぷら2個
+    take_down_time: <%= 1.hour.from_now %>
+    photo_url: https://example.com/photo1.jpg
 
 two:
-  store: two
-  item_name: MyString
-  description: MyText
-  take_down_time: 2025-10-10 12:00:51
-  photo_url: MyString
+    store: two
+    item_name: ぶっかけうどん
+    description: ぶっかけうどん、おにぎり1個
+    take_down_time: <%= 1.hour.from_now %>
+    photo_url: https://example.com/photo2.jpg
+
+without_photo:
+    store: one
+    item_name: カレーうどん
+    description: カレーうどん、サラダ付き
+    take_down_time: <%= 1.hour.from_now %>
+    photo_url: null

--- a/test/models/store_operator_test.rb
+++ b/test/models/store_operator_test.rb
@@ -1,7 +1,30 @@
 require "test_helper"
 
 class StoreOperatorTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "should create store operator" do
+    user = users(:carol)
+    store = stores(:one)
+
+    store_operator = StoreOperator.new(user: user, store: store)
+    assert store_operator.save
+  end
+
+  test "should not create duplicate store operator" do
+    user = users(:bob)
+    store = stores(:one)
+
+    # すでにフィクスチャで存在する
+    duplicate = StoreOperator.new(user: user, store: store)
+    assert_not duplicate.save
+  end
+
+  test "should require user" do
+    store_operator = StoreOperator.new(store: stores(:one))
+    assert_not store_operator.save
+  end
+
+  test "should require store" do
+    store_operator = StoreOperator.new(user: users(:bob))
+    assert_not store_operator.save
+  end
 end

--- a/test/models/store_operator_test.rb
+++ b/test/models/store_operator_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class StoreOperatorTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/udon_share_test.rb
+++ b/test/models/udon_share_test.rb
@@ -1,7 +1,100 @@
 require "test_helper"
 
 class UdonShareTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "should create udon share" do
+    udon_share = UdonShare.new(
+      store: stores(:one),
+      item_name: "かけうどん",
+      description: "大盛り",
+      take_down_time: 2.hours.from_now,
+      photo_url: "https://example.com/photo.jpg"
+    )
+    assert udon_share.save
+  end
+
+  test "should require item_name" do
+    udon_share = UdonShare.new(
+      store: stores(:one),
+      description: "大盛り",
+      take_down_time: 2.hours.from_now,
+      photo_url: "https://example.com/photo.jpg"
+    )
+    assert_not udon_share.save
+  end
+
+  test "should require description" do
+    udon_share = UdonShare.new(
+      store: stores(:one),
+      item_name: "かけうどん",
+      take_down_time: 2.hours.from_now,
+      photo_url: "https://example.com/photo.jpg"
+    )
+    assert_not udon_share.save
+  end
+
+  test "should require take_down_time" do
+    udon_share = UdonShare.new(
+      store: stores(:one),
+      item_name: "かけうどん",
+      description: "大盛り",
+      photo_url: "https://example.com/photo.jpg"
+    )
+    assert_not udon_share.save
+  end
+
+  test "should require photo_url" do
+    udon_share = UdonShare.new(
+      store: stores(:one),
+      item_name: "かけうどん",
+      description: "大盛り",
+      take_down_time: 2.hours.from_now
+    )
+    assert_not udon_share.save
+  end
+
+  test "active scope should return only non-expired shares" do
+    # 有効期限内のシェアを作成
+    active_share = UdonShare.create!(
+      store: stores(:one),
+      item_name: "アクティブ",
+      description: "有効",
+      take_down_time: 2.hours.from_now,
+      photo_url: "https://example.com/photo.jpg"
+    )
+
+    # 期限切れのシェアを作成
+    expired_share = UdonShare.create!(
+      store: stores(:two),
+      item_name: "期限切れ",
+      description: "無効",
+      take_down_time: 2.hours.ago,
+      photo_url: "https://example.com/photo.jpg"
+    )
+
+    active_shares = UdonShare.active
+    assert_includes active_shares, active_share
+    assert_not_includes active_shares, expired_share
+  end
+
+  test "expired? should return true for expired shares" do
+    expired_share = UdonShare.new(
+      store: stores(:one),
+      item_name: "期限切れ",
+      description: "無効",
+      take_down_time: 2.hours.ago,
+      photo_url: "https://example.com/photo.jpg"
+    )
+    assert expired_share.expired?
+  end
+
+  test "expired? should return false for active shares" do
+    active_share = UdonShare.new(
+      store: stores(:one),
+      item_name: "アクティブ",
+      description: "有効",
+      take_down_time: 2.hours.from_now,
+      photo_url: "https://example.com/photo.jpg"
+    )
+    assert_not active_share.expired?
+  end
 end

--- a/test/models/udon_share_test.rb
+++ b/test/models/udon_share_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UdonShareTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/udon_share_test.rb
+++ b/test/models/udon_share_test.rb
@@ -42,14 +42,14 @@ class UdonShareTest < ActiveSupport::TestCase
     assert_not udon_share.save
   end
 
-  test "should require photo_url" do
+  test "photo_url should be optional" do
     udon_share = UdonShare.new(
       store: stores(:one),
       item_name: "かけうどん",
       description: "大盛り",
       take_down_time: 2.hours.from_now
     )
-    assert_not udon_share.save
+    assert udon_share.save
   end
 
   test "active scope should return only non-expired shares" do

--- a/test/system/admin/stores_test.rb
+++ b/test/system/admin/stores_test.rb
@@ -1,0 +1,39 @@
+require "application_system_test_case"
+
+class Admin::StoresTest < ApplicationSystemTestCase
+  setup do
+    @user = users(:bob) # 企業アカウント
+    sign_in_as(@user, password: "passwordbob")
+  end
+
+  test "visiting the index" do
+    visit admin_stores_url
+    assert_selector "h1", text: "運営中の店舗"
+  end
+
+  test "can see add store button on select page" do
+    # 別の店舗を作成
+    Store.create!(name: "New Test Store", address: "123 Test St")
+
+    visit select_admin_stores_url
+
+    # 運営するボタンが存在することを確認
+    assert_selector "button", text: "運営する"
+  end
+
+  test "can see remove store button" do
+    visit admin_stores_url
+
+    # 運営解除ボタンが存在することを確認（アクティブシェアがない店舗用）
+    assert_selector "button", text: "運営解除"
+  end
+
+  test "cannot remove store with active share" do
+    # stores(:one)にはアクティブなシェアがある
+
+    visit admin_stores_url
+
+    # ボタンが無効化されていることを確認
+    assert_selector "button[disabled]", text: "運営解除"
+  end
+end


### PR DESCRIPTION
Introduce models and controllers for managing store operators and udon shares, along with necessary migrations and tests. Implement functionality for adding and removing store operators, and update store information to include eco and share flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - 管理画面：運営店舗一覧・選択、運営者の追加／解除、管理レイアウト・UIを追加
  - うどんシェア：作成／削除、モデル／DB、店舗ごとの共有情報表示（マーカー／情報パネル）を追加
  - ヘッダーに会社ユーザー向け「店舗管理」メニューを追加
- 変更
  - トップAPIで動的なeco/foodshare判定と条件付きshareInfo（時刻整形）を導入
  - DBにis_eco/is_share列およびstore_operators/udon_sharesテーブルを追加、ルーティング／アセット設定／管理用スタイル追
- ドキュメント
  - READMEの文言追記・体裁調整
- テスト
  - 管理画面・シェア機能・モデルの統合／単体／システムテストとフィクスチャを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->