### PR TITLE
fix 測定モデルのテストから「requires turbidity」ケースを削除

### DIFF
--- a/test/models/measurement_test.rb
+++ b/test/models/measurement_test.rb
@@ -1,12 +1,6 @@
 require "test_helper"
 
 class MeasurementTest < ActiveSupport::TestCase
-  test "requires turbidity" do
-    m = Measurement.new
-    assert_not m.valid?
-    assert_includes m.errors[:turbidity], "can't be blank"
-  end
-
   test "enum statuses include expected values" do
     expected = %w[pending predicted validated anomaly]
     assert_equal expected, Measurement.statuses.keys


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* テスト
  * 濁度必須のバリデーションを検証するテストを削除しました。
  * ステータスの列挙値を確認するテストは変更ありません。
  * 本変更はユーザー向けの動作やUIに影響はありませんが、テスト内容を最新の仕様に整合させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->