### PR TITLE
Add store_id to measurements and enhance company user features

### DIFF
--- a/app/controllers/measurements_controller.rb
+++ b/app/controllers/measurements_controller.rb
@@ -2,11 +2,30 @@ class MeasurementsController < ApplicationController
   layout "main"
 
   def index
-    @measurements = Measurement.where(submitter_id: Current.user.id)
+    if Current.user.is_company
+      # 企業アカウントの場合は店舗でフィルタリング可能
+      if params[:store_id].present?
+        @store = Current.user.operated_stores.find_by(id: params[:store_id])
+        @measurements = @store ? @store.measurements : []
+      else
+        # 全店舗の測定データを取得
+        @measurements = Measurement.joins(:store).where(stores: { id: Current.user.operated_stores.pluck(:id) })
+      end
+    else
+      @measurements = Measurement.where(submitter_id: Current.user.id)
+    end
   end
 
   def show
-    @measurement = Measurement.find_by(id: params[:id], submitter_id: Current.user.id)
+    if Current.user.is_company
+      # 企業アカウントは自社店舗の測定データのみアクセス可能
+      @measurement = Measurement.joins(:store).find_by(
+        id: params[:id],
+        stores: { id: Current.user.operated_stores.pluck(:id) }
+      )
+    else
+      @measurement = Measurement.find_by(id: params[:id], submitter_id: Current.user.id)
+    end
 
     if @measurement
       render json: @measurement
@@ -22,10 +41,19 @@ class MeasurementsController < ApplicationController
   end
 
   def create
-    @measurement = Measurement.new(
-      params.require(:measurement).permit(:turbidity, :actual_bod, :actual_cod)
-    )
+    permitted_params = params.require(:measurement).permit(:turbidity, :actual_bod, :actual_cod, :store_id)
+    @measurement = Measurement.new(permitted_params)
     @measurement.submitter = Current.user
+
+    # 企業アカウントの場合はstore_idが必須
+    if Current.user.is_company && !permitted_params[:store_id].present?
+      return render json: { error: "企業アカウントの場合、店舗IDが必要です" }, status: :unprocessable_entity
+    end
+
+    # 一般ユーザーの場合はstore_idを設定しない
+    if !Current.user.is_company
+      @measurement.store_id = nil
+    end
 
     @measurement.predicted_bod = helpers.estimate_bod(@measurement.turbidity)
     @measurement.predicted_cod = helpers.estimate_cod(@measurement.turbidity)

--- a/app/controllers/measurements_controller.rb
+++ b/app/controllers/measurements_controller.rb
@@ -6,10 +6,12 @@ class MeasurementsController < ApplicationController
       # 企業アカウントの場合は店舗でフィルタリング可能
       if params[:store_id].present?
         @store = Current.user.operated_stores.find_by(id: params[:store_id])
-        @measurements = @store ? @store.measurements : []
+        @measurements = @store ? @store.measurements : Measurement.none
       else
-        # 全店舗の測定データを取得
-        @measurements = Measurement.joins(:store).where(stores: { id: Current.user.operated_stores.pluck(:id) })
+         # 全店舗の測定データを取得
+         @measurements = Measurement
+          .where(store_id: Current.user.operated_stores.select(:id))
+          .includes(:store)
       end
     else
       @measurements = Measurement.where(submitter_id: Current.user.id)

--- a/app/controllers/measurements_controller.rb
+++ b/app/controllers/measurements_controller.rb
@@ -21,10 +21,10 @@ class MeasurementsController < ApplicationController
   def show
     if Current.user.is_company
       # 企業アカウントは自社店舗の測定データのみアクセス可能
-      @measurement = Measurement.joins(:store).find_by(
-        id: params[:id],
-        stores: { id: Current.user.operated_stores.pluck(:id) }
-      )
+      @measurement = Measurement
+        .where(id: params[:id], store_id: Current.user.operated_stores.select(:id))
+        .includes(:store)
+        .first
     else
       @measurement = Measurement.find_by(id: params[:id], submitter_id: Current.user.id)
     end

--- a/app/models/measurement.rb
+++ b/app/models/measurement.rb
@@ -1,7 +1,28 @@
 class Measurement < ApplicationRecord
   belongs_to :submitter, class_name: "User"
+  belongs_to :store, optional: true
 
   validates :turbidity, presence: true
+  validate :store_required_for_company_submitter
+  validate :store_belongs_to_company_submitter
 
   enum :status, { pending: 0, predicted: 1, validated: 2, anomaly: 3 }
+
+  private
+
+  def store_required_for_company_submitter
+    return unless submitter&.is_company
+
+    if store_id.blank?
+      errors.add(:store, "企業アカウントの場合、店舗の指定が必要です")
+    end
+  end
+
+  def store_belongs_to_company_submitter
+    return unless submitter&.is_company && store
+
+    unless submitter.operated_stores.include?(store)
+      errors.add(:store, "は企業アカウントが運営する店舗である必要があります")
+    end
+  end
 end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -14,6 +14,9 @@ class Store < ApplicationRecord
   has_many :udon_shares, dependent: :destroy
   has_one :active_udon_share, -> { active.order(created_at: :desc) }, class_name: "UdonShare"
 
+  # 測定データ
+  has_many :measurements, dependent: :destroy
+
   # 現在アクティブなシェアを取得
   def active_udon_share
     super

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,9 @@ class User < ApplicationRecord
   has_many :store_operators, dependent: :destroy
   has_many :operated_stores, through: :store_operators, source: :store
 
+  # 提出した測定データ
+  has_many :submitted_measurements, class_name: "Measurement", foreign_key: "submitter_id", dependent: :destroy
+
   validates :name, presence: true
   normalizes :email, with: ->(email) { email.strip.downcase }
   validates :email, presence: true, uniqueness: true

--- a/db/migrate/20251010163305_add_store_id_to_measurements.rb
+++ b/db/migrate/20251010163305_add_store_id_to_measurements.rb
@@ -1,0 +1,5 @@
+class AddStoreIdToMeasurements < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :measurements, :store, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_10_030050) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_10_163305) do
   create_table "measurements", force: :cascade do |t|
     t.float "turbidity"
     t.float "predicted_bod"
@@ -24,6 +24,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_10_030050) do
     t.integer "submitter_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "store_id"
+    t.index ["store_id"], name: "index_measurements_on_store_id"
     t.index ["submitter_id"], name: "index_measurements_on_submitter_id"
   end
 
@@ -99,6 +101,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_10_030050) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "measurements", "stores"
   add_foreign_key "measurements", "users", column: "submitter_id"
   add_foreign_key "reviews", "stores", column: "reviewee_id"
   add_foreign_key "reviews", "users", column: "reviewer_id"

--- a/test/controllers/measurements_controller_test.rb
+++ b/test/controllers/measurements_controller_test.rb
@@ -5,13 +5,17 @@ class MeasurementsControllerTest < ActionDispatch::IntegrationTest
 
   setup do
     @user = users(:alice)
-    @other = users(:bob)
-    sign_in_as(@user)
+    @company_user = users(:bob)
+    @other = users(:carol)
+    @store_one = stores(:one)
+    @store_two = stores(:two)
   end
 
-  test "index returns only current user's measurements" do
-  m1 = Measurement.create!(turbidity: 10, submitter: @user, predicted_bod: 1.0, predicted_cod: 1.0, status: :predicted)
-  Measurement.create!(turbidity: 20, submitter: @other, predicted_bod: 2.0, predicted_cod: 2.0, status: :predicted)
+  # 一般ユーザーのテスト
+  test "regular user index returns only their measurements" do
+    sign_in_as(@user)
+    m1 = Measurement.create!(turbidity: 10, submitter: @user, predicted_bod: 1.0, predicted_cod: 1.0, status: :predicted)
+    Measurement.create!(turbidity: 20, submitter: @other, predicted_bod: 2.0, predicted_cod: 2.0, status: :predicted)
 
     get measurements_url
     assert_response :success
@@ -21,7 +25,8 @@ class MeasurementsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "show returns measurement JSON for own record" do
+  test "regular user show returns measurement JSON for own record" do
+    sign_in_as(@user)
     m = Measurement.create!(turbidity: 5, submitter: @user, predicted_bod: 1.0, predicted_cod: 1.0, status: :predicted)
 
     get measurement_url(m), as: :json
@@ -31,7 +36,8 @@ class MeasurementsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "predicted", json["status"]
   end
 
-  test "show returns 404 for others record" do
+  test "regular user show returns 404 for others record" do
+    sign_in_as(@user)
     m = Measurement.create!(turbidity: 5, submitter: @other, predicted_bod: 1.0, predicted_cod: 1.0, status: :predicted)
 
     get measurement_url(m), as: :json
@@ -39,6 +45,7 @@ class MeasurementsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "status returns id and status" do
+    sign_in_as(@user)
     m = Measurement.create!(turbidity: 3, submitter: @other, predicted_bod: 1.0, predicted_cod: 1.0, status: :pending)
 
     get status_measurement_url(m), as: :json
@@ -48,7 +55,8 @@ class MeasurementsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "pending", json["status"]
   end
 
-  test "create with valid turbidity creates measurement and sets predicted values" do
+  test "regular user create with valid turbidity creates measurement without store" do
+    sign_in_as(@user)
     turb = 50
     post measurements_url, params: { measurement: { turbidity: turb } }, as: :json
     assert_response :created
@@ -56,13 +64,82 @@ class MeasurementsControllerTest < ActionDispatch::IntegrationTest
 
     m = Measurement.find(json["id"])
     assert_equal @user.id, m.submitter_id
+    assert_nil m.store_id
     assert_not_nil m.predicted_bod
     assert_not_nil m.predicted_cod
     assert_equal "predicted", m.status
   end
 
-  test "create with invalid params returns unprocessable" do
+  test "regular user create with invalid params returns unprocessable" do
+    sign_in_as(@user)
     post measurements_url, params: { measurement: { turbidity: nil } }, as: :json
+    assert_response :unprocessable_entity
+  end
+
+  # 企業ユーザーのテスト
+  test "company user index returns all measurements from their stores" do
+    sign_in_as(@company_user, password: "passwordbob")
+    Measurement.create!(turbidity: 10, submitter: @company_user, store: @store_one, predicted_bod: 1.0, predicted_cod: 1.0, status: :predicted)
+    Measurement.create!(turbidity: 20, submitter: @company_user, store: @store_two, predicted_bod: 2.0, predicted_cod: 2.0, status: :predicted)
+
+    get measurements_url
+    assert_response :success
+  end
+
+  test "company user index with store_id filter returns only that store's measurements" do
+    sign_in_as(@company_user, password: "passwordbob")
+    Measurement.create!(turbidity: 10, submitter: @company_user, store: @store_one, predicted_bod: 1.0, predicted_cod: 1.0, status: :predicted)
+    Measurement.create!(turbidity: 20, submitter: @company_user, store: @store_two, predicted_bod: 2.0, predicted_cod: 2.0, status: :predicted)
+
+    get measurements_url, params: { store_id: @store_one.id }
+    assert_response :success
+  end
+
+  test "company user can view measurements from their stores" do
+    sign_in_as(@company_user, password: "passwordbob")
+    m = Measurement.create!(turbidity: 5, submitter: @company_user, store: @store_one, predicted_bod: 1.0, predicted_cod: 1.0, status: :predicted)
+
+    get measurement_url(m), as: :json
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert_equal m.id, json["id"]
+  end
+
+  test "company user cannot view measurements from other companies" do
+    sign_in_as(@company_user, password: "passwordbob")
+    other_store = Store.create!(name: "Other Store", address: "789 Other St")
+    m = Measurement.create!(turbidity: 5, submitter: @other, store: other_store, predicted_bod: 1.0, predicted_cod: 1.0, status: :predicted)
+
+    get measurement_url(m), as: :json
+    assert_response :not_found
+  end
+
+  test "company user create requires store_id" do
+    sign_in_as(@company_user, password: "passwordbob")
+    post measurements_url, params: { measurement: { turbidity: 50 } }, as: :json
+    assert_response :unprocessable_entity
+    json = JSON.parse(response.body)
+    assert_includes json["error"], "店舗IDが必要です"
+  end
+
+  test "company user create with valid store_id creates measurement" do
+    sign_in_as(@company_user, password: "passwordbob")
+    post measurements_url, params: { measurement: { turbidity: 50, store_id: @store_one.id } }, as: :json
+    assert_response :created
+    json = JSON.parse(response.body)
+
+    m = Measurement.find(json["id"])
+    assert_equal @company_user.id, m.submitter_id
+    assert_equal @store_one.id, m.store_id
+    assert_not_nil m.predicted_bod
+    assert_not_nil m.predicted_cod
+  end
+
+  test "company user cannot create measurement for store they don't operate" do
+    sign_in_as(@company_user, password: "passwordbob")
+    other_store = Store.create!(name: "Other Store", address: "789 Other St")
+
+    post measurements_url, params: { measurement: { turbidity: 50, store_id: other_store.id } }, as: :json
     assert_response :unprocessable_entity
   end
 end

--- a/test/fixtures/measurements.yml
+++ b/test/fixtures/measurements.yml
@@ -1,25 +1,40 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  turbidity: 1.5
-  predicted_bod: 1.5
-  predicted_cod: 1.5
-  actual_bod: 1.5
-  actual_cod: 1.5
-  prediction_model_version: __version__
-  status: 1
-  predicted_at: 2025-09-30 09:26:35
-  submitted_at: 2025-09-30 09:26:35
-  submitter: bob
+    turbidity: 1.5
+    predicted_bod: 1.5
+    predicted_cod: 1.5
+    actual_bod: 1.5
+    actual_cod: 1.5
+    prediction_model_version: __version__
+    status: 1
+    predicted_at: 2025-09-30 09:26:35
+    submitted_at: 2025-09-30 09:26:35
+    submitter: bob
+    store: one
 
 two:
-  turbidity: 1.5
-  predicted_bod: 1.5
-  predicted_cod: 1.5
-  actual_bod: 1.5
-  actual_cod: 1.5
-  prediction_model_version: __version__
-  status: 1
-  predicted_at: 2025-09-30 09:26:35
-  submitted_at: 2025-09-30 09:26:35
-  submitter: bob
+    turbidity: 1.5
+    predicted_bod: 1.5
+    predicted_cod: 1.5
+    actual_bod: 1.5
+    actual_cod: 1.5
+    prediction_model_version: __version__
+    status: 1
+    predicted_at: 2025-09-30 09:26:35
+    submitted_at: 2025-09-30 09:26:35
+    submitter: bob
+    store: two
+
+three:
+    turbidity: 2.0
+    predicted_bod: 2.0
+    predicted_cod: 2.0
+    actual_bod:
+    actual_cod:
+    prediction_model_version: __version__
+    status: 1
+    predicted_at: 2025-09-30 10:00:00
+    submitted_at: 2025-09-30 10:00:00
+    submitter: alice
+    store:

--- a/test/models/measurement_test.rb
+++ b/test/models/measurement_test.rb
@@ -5,4 +5,80 @@ class MeasurementTest < ActiveSupport::TestCase
     expected = %w[pending predicted validated anomaly]
     assert_equal expected, Measurement.statuses.keys
   end
+
+  test "measurement belongs to submitter" do
+    measurement = measurements(:one)
+    assert_equal users(:bob), measurement.submitter
+  end
+
+  test "measurement can belong to a store" do
+    measurement = measurements(:one)
+    assert_equal stores(:one), measurement.store
+  end
+
+  test "measurement can exist without a store for non-company users" do
+    measurement = measurements(:three)
+    assert_nil measurement.store
+    assert_not measurement.submitter.is_company
+  end
+
+  test "company user measurement requires store" do
+    company_user = users(:bob)
+    measurement = Measurement.new(
+      turbidity: 10.0,
+      predicted_bod: 5.0,
+      predicted_cod: 5.0,
+      status: :predicted,
+      submitter: company_user
+    )
+
+    assert_not measurement.valid?
+    assert_includes measurement.errors[:store], "企業アカウントの場合、店舗の指定が必要です"
+  end
+
+  test "company user can only assign measurements to their own stores" do
+    company_user = users(:bob)
+    other_store = Store.create!(name: "Other Store", address: "789 Other St")
+
+    measurement = Measurement.new(
+      turbidity: 10.0,
+      predicted_bod: 5.0,
+      predicted_cod: 5.0,
+      status: :predicted,
+      submitter: company_user,
+      store: other_store
+    )
+
+    assert_not measurement.valid?
+    assert_includes measurement.errors[:store], "は企業アカウントが運営する店舗である必要があります"
+  end
+
+  test "company user can assign measurements to their operated stores" do
+    company_user = users(:bob)
+    own_store = stores(:one)
+
+    measurement = Measurement.new(
+      turbidity: 10.0,
+      predicted_bod: 5.0,
+      predicted_cod: 5.0,
+      status: :predicted,
+      submitter: company_user,
+      store: own_store
+    )
+
+    assert measurement.valid?
+  end
+
+  test "non-company user does not require store" do
+    regular_user = users(:alice)
+    measurement = Measurement.new(
+      turbidity: 10.0,
+      predicted_bod: 5.0,
+      predicted_cod: 5.0,
+      status: :predicted,
+      submitter: regular_user
+    )
+
+    assert measurement.valid?
+  end
 end

--- a/test/models/store_test.rb
+++ b/test/models/store_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class StoreTest < ActiveSupport::TestCase
+  test "store has many measurements" do
+    store = stores(:one)
+    assert_respond_to store, :measurements
+  end
+
+  test "store measurements are destroyed when store is destroyed" do
+    store = stores(:one)
+    company_user = users(:bob)
+
+    Measurement.create!(
+      turbidity: 10.0,
+      predicted_bod: 5.0,
+      predicted_cod: 5.0,
+      status: :predicted,
+      submitter: company_user,
+      store: store
+    )
+
+    # store oneに紐づく測定データ数を確認
+    store_measurement_count = store.measurements.count
+
+    assert_difference("Measurement.count", -store_measurement_count) do
+      store.destroy
+    end
+  end
+
+  test "store can access its measurements" do
+    store = stores(:one)
+    measurements = store.measurements
+
+    assert measurements.all? { |m| m.store_id == store.id }
+  end
+end


### PR DESCRIPTION
Introduce a store_id column to the measurements table and implement foreign key constraints. Add filtering capabilities for company accounts to manage measurement data and enforce validation rules for submitted data. Strengthen related tests for store associations and measurement management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 企業アカウントは自社の運営店舗の測定値を一覧表示・店舗絞り込み可能。作成時は店舗指定が必須で測定値に店舗が紐付く。非企業ユーザーは従来どおり店舗指定は無効化。
* **バグ修正**
  * 権限外または存在しない測定値へのアクセスで一貫して404を返却するよう改善。
* **テスト**
  * 企業/通常ユーザー向けの一覧・表示・作成・バリデーションの網羅的なテストを追加し権限ロジックを強化。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->