### PR TITLE
feat: 測定項目のボタンに強調アニメーションを追加し、ツールチップを実装

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -1082,6 +1082,31 @@ main {
         &:active {
             transform: translateY(0);
         }
+
+        &--emphasis {
+            animation: pulseAttention 1.4s ease-in-out infinite;
+            box-shadow: 0 0 0 0 rgba(248, 113, 113, 0.5);
+
+            &:hover {
+                animation-play-state: paused; // ホバー時は落ち着かせる
+            }
+        }
+    }
+
+    // 強調アニメーション
+    @keyframes pulseAttention {
+        0% {
+            box-shadow: 0 0 0 0 rgba(248, 113, 113, 0.5);
+            transform: translateY(0) scale(1);
+        }
+        50% {
+            box-shadow: 0 0 0 10px rgba(248, 113, 113, 0);
+            transform: translateY(-1px) scale(1.02);
+        }
+        100% {
+            box-shadow: 0 0 0 0 rgba(248, 113, 113, 0);
+            transform: translateY(0) scale(1);
+        }
     }
 
     &__store-selector {

--- a/app/views/measurements/_measurement_item.html.erb
+++ b/app/views/measurements/_measurement_item.html.erb
@@ -30,8 +30,27 @@
         <span class="measures__eco-badge" title="エコバッジ">🌱</span>
       <% end %>
       <% if !measurement.responded? && !measurement.bod_below_limit? %>
-        <%= form_with(url: respond_measurement_path(measurement), method: :post, class: "measures__respond-form", local: false) do |f| %>
-          <%= f.submit "対応する", class: "measures__respond-btn" %>
+        <%# ツールチップ: .tooltip の仕様に合わせたマークアップ %>
+        <% if measurement.predicted_bod.present? && measurement.submitter.present? %>
+          <% limit = measurement.submitter.bod_upper_limit || UserSetting::DEFAULT_SETTINGS[:bod_upper_limit] %>
+          <% if limit.to_f > 0 %>
+            <% ratio = (measurement.predicted_bod.to_f / limit.to_f) %>
+            <% ratio_str = (ratio * 10).round / 10.0 %>
+            <div class="tooltip__container">
+              <%= form_with(url: respond_measurement_path(measurement), method: :post, class: "measures__respond-form", local: false) do |f| %>
+                <%= f.submit "対応する", class: "measures__respond-btn measures__respond-btn--emphasis" %>
+              <% end %>
+              <div class="tooltip__text">※ <%= ratio_str %>倍に希釈してください</div>
+            </div>
+          <% else %>
+            <%= form_with(url: respond_measurement_path(measurement), method: :post, class: "measures__respond-form", local: false) do |f| %>
+              <%= f.submit "対応する", class: "measures__respond-btn measures__respond-btn--emphasis" %>
+            <% end %>
+          <% end %>
+        <% else %>
+          <%= form_with(url: respond_measurement_path(measurement), method: :post, class: "measures__respond-form", local: false) do |f| %>
+            <%= f.submit "対応する", class: "measures__respond-btn measures__respond-btn--emphasis" %>
+          <% end %>
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 予測BODと提出者がある場合、希釈倍率を示すツールチップを表示。
  - 条件が満たされない場合でも、強調表示された送信ボタンで既存フォームを維持。
- スタイル
  - ボタンの強調モディファイアを追加し、パルスアニメーションで注意喚起。
  - ホバー時にパルスアニメーションを一時停止する挙動を追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->